### PR TITLE
Improved support for shared file/folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed `mega::Result<T>` to `mega::Result<T, E = mega::Error>`.
+
 ### Fixed
+
+- Resolved issues when decrypting attributes for shared nodes.
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11,6 +21,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -241,6 +265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -491,6 +516,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +555,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -741,6 +785,7 @@ name = "mega"
 version = "0.4.0"
 dependencies = [
  "aes",
+ "aes-gcm",
  "async-read-progress",
  "async-trait",
  "base64",
@@ -751,6 +796,7 @@ dependencies = [
  "ctr",
  "futures",
  "hex",
+ "hkdf",
  "indicatif",
  "pbkdf2",
  "rand",
@@ -869,6 +915,12 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -992,6 +1044,18 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "polyval"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1510,6 +1574,16 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,11 @@ aes = "0.8.2"
 cbc = "0.1.2"
 ctr = "0.9.2"
 rsa = "0.8.1"
+sha2 = "0.10.6"
 cipher = { version = "0.4.3", features = ["block-padding"] }
+aes-gcm = { version = "0.10.1", features = ["std"] }
 pbkdf2 = { version = "0.11.0", features = ["std"] }
+hkdf = { version = "0.12.3", features = ["std"] }
 
 # `reqwest` support
 reqwest = { version = "0.11.14", features = ["json", "stream"], optional = true }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -90,6 +90,19 @@ pub enum Request {
     /// Message for getting information about the current user.
     #[serde(rename = "ug")]
     UserInfo {},
+    /// Message for fetching user-related attributes.
+    #[serde(rename = "uga")]
+    UserAttributes {
+        /// The user's handle.
+        #[serde(rename = "u")]
+        user_handle: String,
+        /// The name of the attribute to fetch.
+        #[serde(rename = "ua")]
+        attribute: String,
+        /// `v` should be 1 (otherwise the output is not a JSON object).
+        #[serde(rename = "v")]
+        v: i32,
+    },
     /// Message for getting the current storage quotas.
     #[serde(rename = "uq")]
     Quota {
@@ -226,6 +239,8 @@ pub enum Response {
     Logout(LogoutResponse),
     /// Response for the `Request::UserInfo` message.
     UserInfo(UserInfoResponse),
+    /// Response for the `Request::UserAttributes` message.
+    UserAttributes(UserAttributesResponse),
     /// Response for the `Request::Quota` message.
     Quota(QuotaResponse),
     /// Response for the `Request::FetchNodes` message.
@@ -303,6 +318,20 @@ pub struct UserInfoResponse {
     pub ts: String,
 }
 
+/// Response for the `Request::UserAttributes` message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserAttributesResponse {
+    /// The version identifier for the attribute (for caching purposes, it seems).
+    #[serde(rename = "v")]
+    pub v: String,
+    /// The attribute's value.
+    #[serde(rename = "av")]
+    pub attr_value: String,
+    /// Catch-all for the remaining fields (if any).
+    #[serde(flatten)]
+    pub other: HashMap<String, Value>,
+}
+
 /// Response for the `Request::Quota` message.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QuotaResponse {
@@ -322,6 +351,8 @@ pub struct QuotaResponse {
 pub struct FileMetadata {
     #[serde(rename = "h")]
     pub hash: String,
+    #[serde(rename = "ha")]
+    pub hash_auth: String,
     #[serde(rename = "k")]
     pub key: String,
 }
@@ -494,6 +525,10 @@ impl Request {
             Request::UserInfo { .. } => {
                 let response = json::from_value(value)?;
                 Response::UserInfo(response)
+            }
+            Request::UserAttributes { .. } => {
+                let response = json::from_value(value)?;
+                Response::UserAttributes(response)
             }
             Request::Quota { .. } => {
                 let response = json::from_value(value)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use thiserror::Error;
 
 /// The `Result` type for this library.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// The main error type for this library.
 #[derive(Debug, Error)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// The main error type for this library.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// Missing user session.
+    #[error("missing user session (consider logging in first)")]
+    MissingUserSession,
     /// Invalid server response type.
     #[error("invalid server response type")]
     InvalidResponseType,
@@ -45,8 +48,17 @@ pub enum Error {
     #[error("base64 encode error: {0}")]
     Base64DecodeError(#[from] base64::DecodeError),
     /// PBKDF2 error.
-    #[error("pbkdf2 error: {0}")]
+    #[error("PBKDF2 error: {0}")]
     Pbkdf2Error(#[from] pbkdf2::password_hash::Error),
+    /// HKDF error (invalid length).
+    #[error("HKDF error: {0}")]
+    HkdfInvalidLengthError(#[from] hkdf::InvalidLength),
+    /// HKDF error (invalid PRK length).
+    #[error("HKDF error: {0}")]
+    HkdfInvalidPrkLengthError(#[from] hkdf::InvalidPrkLength),
+    /// AES-GCM error.
+    #[error("AES-GCM error: {0}")]
+    AesGcmError(#[from] aes_gcm::Error),
     /// MEGA error (error codes from API).
     #[error("MEGA error: {0}")]
     MegaError(#[from] ErrorCode),

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -19,6 +19,8 @@ pub struct UserSession {
     pub(crate) sid: String,
     /// The user's master key.
     pub(crate) key: [u8; 16],
+    /// The user's handle.
+    pub(crate) user_handle: String,
 }
 
 /// Stores the data representing the client's state.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,24 @@
+use std::collections::HashMap;
+
 use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockEncrypt, KeyInit};
 use aes::Aes128;
+use aes_gcm::{AeadInPlace, Aes128Gcm};
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+use base64::Engine;
+use chrono::{DateTime, TimeZone, Utc};
 use cipher::{BlockDecrypt, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use hkdf::Hkdf;
+use json::Value;
 use pbkdf2::password_hash::{PasswordHasher, Salt};
 use pbkdf2::{Algorithm, Params, Pbkdf2};
 use rand::distributions::{Alphanumeric, DistString};
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 
-use crate::error::Error;
+use crate::commands::UserAttributesResponse;
+use crate::http::UserSession;
+use crate::{Client, Node, Result};
 
 /// Represents storage quotas from MEGA.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -27,7 +38,7 @@ pub(crate) struct FileAttributes {
 }
 
 impl FileAttributes {
-    pub(crate) fn decrypt_and_unpack(file_key: &[u8], buffer: &mut [u8]) -> Result<Self, Error> {
+    pub(crate) fn decrypt_and_unpack(file_key: &[u8], buffer: &mut [u8]) -> Result<Self> {
         let mut cbc = cbc::Decryptor::<Aes128>::new(file_key.into(), &<_>::default());
         for chunk in buffer.chunks_exact_mut(16) {
             cbc.decrypt_block_mut(chunk.into());
@@ -41,7 +52,7 @@ impl FileAttributes {
         Ok(attrs)
     }
 
-    pub(crate) fn pack_and_encrypt(&self, file_key: &[u8]) -> Result<Vec<u8>, Error> {
+    pub(crate) fn pack_and_encrypt(&self, file_key: &[u8]) -> Result<Vec<u8>> {
         let mut buffer = b"MEGA".to_vec();
         json::to_writer(&mut buffer, self)?;
 
@@ -75,7 +86,7 @@ pub(crate) fn prepare_key_v1(password: &[u8]) -> [u8; 16] {
     data.into()
 }
 
-pub(crate) fn prepare_key_v2(password: &[u8], salt: &str) -> Result<Vec<u8>, Error> {
+pub(crate) fn prepare_key_v2(password: &[u8], salt: &str) -> Result<Vec<u8>> {
     let salt = Salt::new(salt)?;
     let params = Params {
         rounds: 100_000,
@@ -148,6 +159,113 @@ pub(crate) fn merge_key_mac(key: &mut [u8]) {
 pub(crate) fn random_string(len: usize) -> String {
     let mut rng = rand::thread_rng();
     Alphanumeric.sample_string(&mut rng, len)
+}
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum KeysAttrTag {
+    Version = 1,
+    CreationTime = 2,
+    Identity = 3,
+    Generation = 4,
+    Attr = 5,
+    PrivEd25519 = 16,
+    PrivCu25519 = 17,
+    PrivRsa = 18,
+    AuthringEd25519 = 32,
+    AuthringCu25519 = 33,
+    ShareKeys = 48,
+    PendingOutshares = 64,
+    PendingInshares = 65,
+    Backups = 80,
+    Warnings = 96,
+}
+
+impl TryFrom<u8> for KeysAttrTag {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(KeysAttrTag::Version),
+            2 => Ok(KeysAttrTag::CreationTime),
+            3 => Ok(KeysAttrTag::Identity),
+            4 => Ok(KeysAttrTag::Generation),
+            5 => Ok(KeysAttrTag::Attr),
+            16 => Ok(KeysAttrTag::PrivEd25519),
+            17 => Ok(KeysAttrTag::PrivCu25519),
+            18 => Ok(KeysAttrTag::PrivRsa),
+            32 => Ok(KeysAttrTag::AuthringEd25519),
+            33 => Ok(KeysAttrTag::AuthringCu25519),
+            48 => Ok(KeysAttrTag::ShareKeys),
+            64 => Ok(KeysAttrTag::PendingOutshares),
+            65 => Ok(KeysAttrTag::PendingInshares),
+            80 => Ok(KeysAttrTag::Backups),
+            96 => Ok(KeysAttrTag::Warnings),
+            _ => Err(()),
+        }
+    }
+}
+
+pub(crate) fn extract_share_keys(
+    session: &UserSession,
+    attr: &UserAttributesResponse,
+) -> Result<HashMap<String, Vec<u8>>> {
+    let hkdf = Hkdf::<Sha256>::new(None, &session.key);
+    let mut derived_key = [0u8; 16];
+    hkdf.expand(&[1], &mut derived_key)?;
+
+    let attr_value = BASE64_URL_SAFE_NO_PAD.decode(&attr.attr_value)?;
+
+    // the attribute value consists of:
+    // - 1 byte guaranteed to be `20`.
+    // - 1 byte that is declared reserved (usually `0`).
+    // - 12 bytes of IV data suitable for the AES-128-GCM algorithm.
+    // - arbitrarily-sized payload to be decrypted using AES-128-GCM.
+
+    assert_eq!(attr_value[0], 20);
+    let (iv, data) = attr_value[2..].split_at(12);
+    let gcm = Aes128Gcm::new(derived_key.as_slice().into());
+    let mut data = data.to_vec();
+    gcm.decrypt_in_place(iv.into(), &[], &mut data)?;
+
+    // this attribute's payload consists of a variable number of "packets"
+    // that are prefixed with a tag (1 byte) and the length of their payload (3 bytes).
+
+    let mut share_keys = HashMap::default();
+
+    let mut cursor = 0;
+    while cursor < data.len() {
+        let Ok(tag) = KeysAttrTag::try_from(data[cursor]) else {
+            continue;
+        };
+        let len = (usize::from(data[cursor + 1]) << 16)
+            + (usize::from(data[cursor + 2]) << 8)
+            + usize::from(data[cursor + 3]);
+        cursor += 4;
+
+        if tag == KeysAttrTag::ShareKeys {
+            // The share keys section consists of multiple 23 bytes long chunks,
+            // each corresponding to a single share key.
+            // Each chunk consists of:
+            // - the shared node's handle (6 bytes)
+            // - the node's share key (16 bytes)
+            // - trust flag (1 byte)
+            //   (this flag seems to have to do with whether the key has been "exposed" in some way?)
+
+            for chunk in data[cursor..(cursor + len)].chunks(23) {
+                let (handle, rest) = chunk.split_at(6);
+                let (share_key, _trust) = rest.split_at(16);
+                let handle = BASE64_URL_SAFE_NO_PAD.encode(handle);
+                share_keys.insert(handle, share_key.to_vec());
+            }
+
+            break;
+        }
+
+        cursor += len;
+    }
+
+    Ok(share_keys)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
While testing the library, I noticed that some existant MEGA nodes were missing in the output from `Client::fetch_own_nodes`, which seems like a quite serious issue.  

Looking into it, I found that this was due to these nodes' keys being encrypted using share keys instead of simply the user's master key.  

When writing this library, I initially implemented how to decrypt the nodes' keys by looking at how some of the other unofficial libraries (like `MEGAJS` or `go-mega`) did things, because reverse-engineering MEGA's SDK and web client is quite a bit more complex (due to the bigger amounts of features supported, lots of vulnerability mitigations, and backwards compatibility support with previously-emitted keys).  

But it turned out that both of these libraries are currently failing to decrypt the attributes for the same nodes I had issues with (essentially failing to find the correct key), whereas `MEGAcmd` had no such issues and listed the node with all their attributes without any problem.  

So, this new implementation is now based on how MEGA's webclient and `MEGAcmd` does things (through some serious reverse-engineering), which now issues a `uga` API query to look up the user's `^!keys` attribute, deciphers it using HMAC key derivation (HKDF) and AES-128-GCM and deserializes the result to obtain the correct share keys.

This not only fixed the bugs on my end but also brings the library closer to MEGA's own methodology of doing things.