### PR TITLE
Added node fingerprinting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed handling of folder keys.
 - Fixed folder key generation in `Client::create_dir`.
 - Fixed last modification dates being overwritten when renaming nodes.
+- Fixed occasional `MALFORMED_ATTRIBUTES` issue due to incorrect attributes buffer padding.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Node::modified_at`.
+- Added `Node::checksum`.
+- Added `compute_sparse_checksum` standalone function.
+
 ### Changed
 
+- Renamed `Node::hash` to `Node::handle`.
+- Renamed `Nodes::get_node_by_hash` to `Nodes::get_node_by_handle`.
 - Changed `mega::Result<T>` to `mega::Result<T, E = mega::Error>`.
+- Changed `Node::created_at` to return an owned `DateTime<Utc>` instead of borrowing.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Node::sparse_checksum`.
 - Added `compute_sparse_checksum` standalone function.
 - Added `compute_condensed_mac` standalone function.
+- Added `LastModified` enum.
 
 ### Changed
 
@@ -25,12 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `Nodes::get_node_by_hash` to `Nodes::get_node_by_handle`.
 - Changed `mega::Result<T>` to `mega::Result<T, E = mega::Error>`.
 - Changed `Node::created_at` to return an owned `DateTime<Utc>` instead of borrowing.
+- Changed `Client::upload_node` to now accept a last modification date (using `LastModified`).
 
 ### Fixed
 
 - Resolved issues when decrypting attributes for shared nodes.
 - Fixed handling of folder keys.
 - Fixed folder key generation in `Client::create_dir`.
+- Fixed last modification dates being overwritten when renaming nodes.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed handling of folder keys.
 - Fixed folder key generation in `Client::create_dir`.
 - Fixed last modification dates being overwritten when renaming nodes.
-- Fixed occasional `MALFORMED_ATTRIBUTES` issue due to incorrect attributes buffer padding.
 
 ### Removed
+
+[0.4.1] - 2023-05-25
+--------------------
+
+### Fixed
+
+- Fixed occasional `MALFORMED_ATTRIBUTES` issue due to incorrect attributes buffer padding.
 
 [0.4.0] - 2023-04-12
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `Node::modified_at`.
-- Added `Node::checksum`.
+- Added `Node::aes_key`.
+- Added `Node::aes_iv`.
+- Added `Node::condensed_mac`.
+- Added `Node::sparse_checksum`.
 - Added `compute_sparse_checksum` standalone function.
+- Added `compute_condensed_mac` standalone function.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +802,7 @@ dependencies = [
  "chrono",
  "cipher",
  "console",
+ "crc32fast",
  "ctr",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ aes-gcm = { version = "0.10.1", features = ["std"] }
 pbkdf2 = { version = "0.11.0", features = ["std"] }
 hkdf = { version = "0.12.3", features = ["std"] }
 
+# Checksum computation
+crc32fast = "1.3.2"
+
 # `reqwest` support
 reqwest = { version = "0.11.14", features = ["json", "stream"], optional = true }
 tokio = { version = "1.25.0", features = ["time"], optional = true }

--- a/examples/checksum_comparison.rs
+++ b/examples/checksum_comparison.rs
@@ -1,0 +1,93 @@
+//!
+//! Example program that simply checks if a local file is similar to a MEGA file
+//! using a CRC32-based sparse checksum with progress reporting.
+//!
+
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_read_progress::AsyncReadProgressExt;
+use console::style;
+use indicatif::{ProgressBar, ProgressStyle};
+use tokio::fs::File;
+use tokio_util::compat::TokioAsyncReadCompatExt;
+
+async fn run(
+    mega: &mut mega::Client,
+    local_file_path: &str,
+    distant_file_path: &str,
+) -> mega::Result<()> {
+    let nodes = mega.fetch_own_nodes().await?;
+
+    let node = nodes
+        .get_node_by_path(distant_file_path)
+        .expect("could not find node by path");
+
+    let Some(remote_checksum) = node.checksum() else {
+        println!("remote node doesn't have a checksum available");
+        return Ok(());
+    };
+
+    let bar = ProgressBar::new(node.size());
+    bar.set_style(progress_bar_style());
+    bar.set_message(format!("computing checksum for {local_file_path}..."));
+
+    let file = File::open(local_file_path).await?;
+    let size = usize::try_from(file.metadata().await?.len()).unwrap();
+
+    let bar = Arc::new(bar);
+
+    let reader = {
+        let bar = bar.clone();
+        file.compat()
+            .report_progress(Duration::from_millis(100), move |bytes_read| {
+                bar.set_position(bytes_read as u64);
+            })
+    };
+
+    let local_checksum = mega::compute_sparse_checksum(reader, size).await?;
+    bar.finish_and_clear();
+
+    if local_checksum == remote_checksum {
+        println!("OK ! (the checksums are identical)");
+    } else {
+        println!("FAILED ! (the checksums differ)");
+    }
+
+    Ok(())
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let email = env::var("MEGA_EMAIL").expect("missing MEGA_EMAIL environment variable");
+    let password = env::var("MEGA_PASSWORD").expect("missing MEGA_PASSWORD environment variable");
+    let mfa = env::var("MEGA_MFA").ok();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let [local_file_path, distant_file_path] = args.as_slice() else {
+        panic!("expected 2 command-line arguments: {{local_file_path}} {{distant_file_path}}");
+    };
+
+    let http_client = reqwest::Client::new();
+    let mut mega = mega::Client::builder().build(http_client).unwrap();
+
+    mega.login(&email, &password, mfa.as_deref()).await.unwrap();
+    let result = run(&mut mega, local_file_path, distant_file_path).await;
+    mega.logout().await.unwrap();
+
+    result.unwrap();
+}
+
+pub fn progress_bar_style() -> ProgressStyle {
+    let template = format!(
+        "{}{{bar:30.magenta.bold/magenta/bold}}{} {{percent}} % (ETA {{eta}}): {{msg}}",
+        style("▐").bold().magenta(),
+        style("▌").bold().magenta(),
+    );
+
+    ProgressStyle::default_bar()
+        .progress_chars("▨▨╌")
+        .template(template.as_str())
+        .unwrap()
+}

--- a/examples/simple_upload.rs
+++ b/examples/simple_upload.rs
@@ -38,8 +38,14 @@ async fn run(mega: &mut mega::Client, file: &str, folder: &str) -> mega::Result<
         })
     };
 
-    mega.upload_node(&node, file_name, size, reader.compat())
-        .await?;
+    mega.upload_node(
+        &node,
+        file_name,
+        size,
+        reader.compat(),
+        mega::LastModified::Now,
+    )
+    .await?;
 
     bar.finish_with_message(format!("{0} uploaded !", node.name()));
 
@@ -61,7 +67,6 @@ async fn main() {
     let mut mega = mega::Client::builder().build(http_client).unwrap();
 
     mega.login(&email, &password, mfa.as_deref()).await.unwrap();
-
     let result = run(&mut mega, file, folder).await;
     mega.logout().await.unwrap();
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -44,7 +44,7 @@ impl NodeAttributes {
         let mut buffer = b"MEGA".to_vec();
         json::to_writer(&mut buffer, self)?;
 
-        let padding_len = (16 - buffer.len() % 16).min(15);
+        let padding_len = (16 - buffer.len() % 16) % 16;
         buffer.extend(std::iter::repeat(b'\0').take(padding_len));
 
         let mut cbc = cbc::Encryptor::<Aes128>::new(file_key.into(), &<_>::default());

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+
+use aes::Aes128;
+use cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use json::Value;
+use serde::{Deserialize, Serialize};
+
+use crate::fingerprint::NodeFingerprint;
+use crate::Result;
+
+/// Represents the node's attributes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct NodeAttributes {
+    /// The name of the node.
+    #[serde(rename = "n")]
+    pub name: String,
+    /// The encoded fingerprint for the node.
+    #[serde(rename = "c", skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<String>,
+    /// The last modified date of the node.
+    #[serde(rename = "t", skip_serializing_if = "Option::is_none")]
+    pub modified_at: Option<i64>,
+    /// Catch-all for the remaining fields (if any).
+    #[serde(flatten)]
+    pub other: HashMap<String, Value>,
+}
+
+impl NodeAttributes {
+    pub(crate) fn decrypt_and_unpack(file_key: &[u8], buffer: &mut [u8]) -> Result<Self> {
+        let mut cbc = cbc::Decryptor::<Aes128>::new(file_key.into(), &<_>::default());
+        for chunk in buffer.chunks_exact_mut(16) {
+            cbc.decrypt_block_mut(chunk.into());
+        }
+
+        assert_eq!(&buffer[..4], b"MEGA");
+
+        let len = buffer.iter().take_while(|it| **it != b'\0').count();
+        let attrs = json::from_slice(&buffer[4..len])?;
+
+        Ok(attrs)
+    }
+
+    pub(crate) fn pack_and_encrypt(&self, file_key: &[u8]) -> Result<Vec<u8>> {
+        let mut buffer = b"MEGA".to_vec();
+        json::to_writer(&mut buffer, self)?;
+
+        let padding_len = (16 - buffer.len() % 16).min(15);
+        buffer.extend(std::iter::repeat(b'\0').take(padding_len));
+
+        let mut cbc = cbc::Encryptor::<Aes128>::new(file_key.into(), &<_>::default());
+        for chunk in buffer.chunks_exact_mut(16) {
+            cbc.encrypt_block_mut(chunk.into());
+        }
+
+        Ok(buffer)
+    }
+
+    pub(crate) fn extract_fingerprint(&self) -> Option<NodeFingerprint> {
+        let checksum = self.fingerprint.as_deref()?;
+        NodeFingerprint::deserialize(checksum)
+    }
+}

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -26,7 +26,7 @@ pub(crate) struct NodeAttributes {
 }
 
 impl NodeAttributes {
-    pub(crate) fn decrypt_and_unpack(file_key: &[u8], buffer: &mut [u8]) -> Result<Self> {
+    pub(crate) fn decrypt_and_unpack(file_key: &[u8; 16], buffer: &mut [u8]) -> Result<Self> {
         let mut cbc = cbc::Decryptor::<Aes128>::new(file_key.into(), &<_>::default());
         for chunk in buffer.chunks_exact_mut(16) {
             cbc.decrypt_block_mut(chunk.into());
@@ -40,7 +40,7 @@ impl NodeAttributes {
         Ok(attrs)
     }
 
-    pub(crate) fn pack_and_encrypt(&self, file_key: &[u8]) -> Result<Vec<u8>> {
+    pub(crate) fn pack_and_encrypt(&self, file_key: &[u8; 16]) -> Result<Vec<u8>> {
         let mut buffer = b"MEGA".to_vec();
         json::to_writer(&mut buffer, self)?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     /// Invalid (or unsupported) public URL format.
     #[error("invalid (or unsupported) public URL format")]
     InvalidPublicUrlFormat,
+    /// Invalid node checksum format.
+    #[error("invalid node checksum format")]
+    InvalidChecksumFormat,
     /// Invalid server response type.
     #[error("invalid server response type")]
     InvalidResponseType,

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -1,6 +1,8 @@
 use std::pin::pin;
 
+use aes::Aes128;
 use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
+use cipher::{BlockEncryptMut, KeyIvInit};
 use futures::io::{AsyncRead, AsyncReadExt};
 
 use crate::Result;
@@ -23,11 +25,7 @@ impl NodeFingerprint {
     }
 
     #[allow(unused)]
-    pub async fn from_reader<R: AsyncRead>(
-        reader: R,
-        size: usize,
-        modified_at: i64,
-    ) -> Result<Self> {
+    pub async fn from_reader<R: AsyncRead>(reader: R, size: u64, modified_at: i64) -> Result<Self> {
         Ok(Self::new(
             compute_sparse_checksum(reader, size).await?,
             modified_at,
@@ -81,34 +79,45 @@ impl NodeFingerprint {
 ///
 /// This allows to compute a checksum for any arbitrary data and compare it to the ones of remote MEGA nodes.
 ///
+/// Please be aware that, due to these checksums being sparse, two identical checksums can be identical to
+/// one another despite being generated from very slightly different files.
+///
+/// Using condensed MACs is more accurate to assess file integrity than the sparse checksum method,
+/// but it is both more CPU and disk intensive to do so.
+///
 /// Here is an example of how to use this function:
 /// ```rust,no_run
-/// # fn main() {
+/// # async fn example() -> mega::Result<()> {
+/// # let http_client = reqwest::Client::new();
+/// # let mega = mega::Client::builder().build(http_client)?;
+/// use tokio_util::compat::TokioAsyncReadCompatExt;
+///
 /// let nodes = mega.fetch_own_nodes().await?;
 ///
 /// let remote_checksum = {
 ///     let node = nodes.get_node_by_path("/Root/some-remote-file.txt").unwrap();
-///     node.checksum().unwrap()
+///     node.sparse_checksum().unwrap()
 /// };
 ///
 /// let local_checksum = {
-///     let file = File::open("some-local-file.txt").await?;
+///     let file = tokio::fs::File::open("some-local-file.txt").await?;
 ///     let size = file.metadata().await?.len();
-///     mega::compute_checksum(file, size).await?
+///     mega::compute_sparse_checksum(file.compat(), size).await?
 /// };
 ///
-/// if local_checksum == remote_checksum {
+/// if local_checksum == *remote_checksum {
 ///     println!("OK ! (the checksums are identical)");
 /// } else {
 ///     println!("FAILED ! (the checksums differ)");
 /// }
+/// # Ok(())
 /// # }
 /// ```
-pub async fn compute_sparse_checksum<R: AsyncRead>(reader: R, size: usize) -> Result<[u8; 16]> {
-    const MAXFULL: usize = 8192;
+pub async fn compute_sparse_checksum<R: AsyncRead>(reader: R, size: u64) -> Result<[u8; 16]> {
+    const MAXFULL: u64 = 8192;
 
-    const CRC_SIZE: usize = 16;
-    const BLOCK_SIZE: usize = CRC_SIZE * 4;
+    const CRC_SIZE: u64 = 16;
+    const BLOCK_SIZE: u64 = CRC_SIZE * 4;
 
     match size {
         size if size <= 16 => {
@@ -119,6 +128,7 @@ pub async fn compute_sparse_checksum<R: AsyncRead>(reader: R, size: usize) -> Re
         }
         size if size <= MAXFULL => {
             // small file: full coverage, four full CRC32s.
+            let size = usize::try_from(size).unwrap();
             let mut buffer = vec![0u8; size];
             pin!(reader).read_exact(&mut buffer).await?;
 
@@ -138,9 +148,12 @@ pub async fn compute_sparse_checksum<R: AsyncRead>(reader: R, size: usize) -> Re
         }
         size => {
             // large file: sparse coverage, four sparse CRC32s.
-            let mut reader = pin!(reader);
+            let mut reader = {
+                let size = u64::try_from(size).unwrap();
+                pin!(reader.take(size))
+            };
 
-            let mut block = [0u8; BLOCK_SIZE];
+            let mut block = [0u8; BLOCK_SIZE as usize];
             let blocks = MAXFULL / (BLOCK_SIZE * 4);
 
             let mut checksum = [0u8; 16];
@@ -150,7 +163,7 @@ pub async fn compute_sparse_checksum<R: AsyncRead>(reader: R, size: usize) -> Re
                 let mut hasher = crc32fast::Hasher::new();
                 for blk in 0..blocks {
                     let offset = (size - BLOCK_SIZE) * (idx * blocks + blk) / (4 * blocks - 1);
-                    let gap = u64::try_from(offset - cursor).unwrap();
+                    let gap = offset - cursor;
                     futures::io::copy((&mut reader).take(gap), &mut futures::io::sink()).await?;
                     (&mut reader).read_exact(&mut block).await?;
                     hasher.update(&block);
@@ -159,11 +172,115 @@ pub async fn compute_sparse_checksum<R: AsyncRead>(reader: R, size: usize) -> Re
 
                 let crc = hasher.finalize();
 
-                let begin = idx * 4;
+                let begin = usize::try_from(idx * 4).unwrap();
                 checksum[begin..(begin + 4)].copy_from_slice(&crc.to_be_bytes());
             }
 
             Ok(checksum)
         }
     }
+}
+
+/// This function computes a full-coverage condensed MAC, in the exact same way that MEGA does it.
+///
+/// This allows to compute a condensed MAC for any arbitrary data and compare it to the ones of remote MEGA nodes.
+///
+/// Using these MACs is more accurate to assess file integrity than the sparse checksum method,
+/// but it is both more CPU and disk intensive to do so.
+///
+/// Here is an example of how to use this function:
+/// ```rust,no_run
+/// # async fn example() -> mega::Result<()> {
+/// # let http_client = reqwest::Client::new();
+/// # let mega = mega::Client::builder().build(http_client)?;
+/// use tokio_util::compat::TokioAsyncReadCompatExt;
+///
+/// let nodes = mega.fetch_own_nodes().await?;
+///
+/// let (remote_condensed_mac, key, iv) = {
+///     let node = nodes.get_node_by_path("/Root/some-remote-file.txt").unwrap();
+///     let condensed_mac = node.condensed_mac().unwrap();
+///     let key = node.aes_key();
+///     let iv = node.aes_iv().unwrap();
+///     (condensed_mac, key, iv)
+/// };
+///
+/// let local_condensed_mac = {
+///     let file = tokio::fs::File::open("some-local-file.txt").await?;
+///     let size = file.metadata().await?.len();
+///     mega::compute_condensed_mac(file.compat(), size, key, iv).await?
+/// };
+///
+/// if local_condensed_mac == *remote_condensed_mac {
+///     println!("OK ! (the MACs are identical)");
+/// } else {
+///     println!("FAILED ! (the MACs differ)");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub async fn compute_condensed_mac<R: AsyncRead>(
+    reader: R,
+    size: u64,
+    aes_key: &[u8; 16],
+    aes_iv: &[u8; 8],
+) -> Result<[u8; 8]> {
+    let mut chunk_size: u64 = 131_072; // 2^17
+    let mut cur_mac = [0u8; 16];
+
+    let mut final_mac_data = [0u8; 16];
+    let mut final_mac = cbc::Encryptor::<Aes128>::new(aes_key.into(), (&final_mac_data).into());
+
+    let mut buffer = {
+        let chunk_size = usize::try_from(chunk_size).unwrap();
+        Vec::with_capacity(chunk_size)
+    };
+
+    let mut reader = pin!(reader.take(size));
+
+    let aes_iv = {
+        let mut data = [0u8; 16];
+        data[..8].copy_from_slice(aes_iv);
+        data[8..].copy_from_slice(aes_iv);
+        data
+    };
+
+    loop {
+        buffer.clear();
+
+        let bytes_read = (&mut reader)
+            .take(chunk_size)
+            .read_to_end(&mut buffer)
+            .await?;
+
+        if bytes_read == 0 {
+            break;
+        }
+
+        let (chunks, leftover) = buffer.split_at(buffer.len() - buffer.len() % 16);
+
+        let mut mac = cbc::Encryptor::<Aes128>::new(aes_key.into(), (&aes_iv).into());
+        for chunk in chunks.chunks_exact(16) {
+            mac.encrypt_block_b2b_mut(chunk.into(), (&mut cur_mac).into());
+        }
+
+        if !leftover.is_empty() {
+            let mut padded_chunk = [0u8; 16];
+            padded_chunk[..leftover.len()].copy_from_slice(leftover);
+            mac.encrypt_block_b2b_mut((&padded_chunk).into(), (&mut cur_mac).into());
+        }
+
+        final_mac.encrypt_block_b2b_mut((&cur_mac).into(), (&mut final_mac_data).into());
+
+        if chunk_size < 1_048_576 {
+            chunk_size += 131_072;
+        }
+    }
+
+    for i in 0..4 {
+        final_mac_data[i] = final_mac_data[i] ^ final_mac_data[i + 4];
+        final_mac_data[i + 4] = final_mac_data[i + 8] ^ final_mac_data[i + 12];
+    }
+
+    Ok(final_mac_data[..8].try_into().unwrap())
 }

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -1,0 +1,169 @@
+use std::pin::pin;
+
+use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
+use futures::io::{AsyncRead, AsyncReadExt};
+
+use crate::Result;
+
+/// Represents the node's fingerprint (useful for caching purposes).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct NodeFingerprint {
+    /// The checksum bytes of the node.
+    pub checksum: [u8; 16],
+    /// The last modified date of the node.
+    pub modified_at: i64,
+}
+
+impl NodeFingerprint {
+    pub fn new(checksum: [u8; 16], modified_at: i64) -> Self {
+        Self {
+            checksum,
+            modified_at,
+        }
+    }
+
+    #[allow(unused)]
+    pub async fn from_reader<R: AsyncRead>(
+        reader: R,
+        size: usize,
+        modified_at: i64,
+    ) -> Result<Self> {
+        Ok(Self::new(
+            compute_sparse_checksum(reader, size).await?,
+            modified_at,
+        ))
+    }
+
+    pub fn deserialize(checksum_str: &str) -> Option<Self> {
+        let decoded = BASE64_URL_SAFE_NO_PAD.decode(checksum_str).ok()?;
+
+        let (checksum, mtime) = decoded.split_at(16);
+        let checksum = checksum.try_into().ok()?;
+
+        let modified_at = {
+            let (byte_count, mtime) = mtime.split_first().map(|(a, b)| (usize::from(*a), b))?;
+
+            if byte_count > 8 || byte_count > mtime.len() {
+                // incorrect byte count.
+                return None;
+            }
+
+            mtime[..byte_count]
+                .into_iter()
+                .rev()
+                .copied()
+                .fold(0, |acc, byte| (acc << 8) + i64::from(byte))
+        };
+
+        Some(Self::new(checksum, modified_at))
+    }
+
+    pub fn serialize(&self) -> String {
+        let mut buffer = vec![0u8; 16 + 8];
+
+        buffer[..16].copy_from_slice(&self.checksum);
+
+        let mut value = self.modified_at;
+        let mut byte_count: u8 = 0;
+        while value > 0 {
+            buffer[16 + usize::from(byte_count)] = u8::try_from(value & 0xFF).unwrap();
+            value >>= 8;
+            byte_count += 1;
+        }
+        buffer[16] = byte_count;
+
+        let bytes_written = 16 + usize::from(byte_count) + 1;
+        BASE64_URL_SAFE_NO_PAD.encode(&buffer[..bytes_written])
+    }
+}
+
+/// This function computes a sparse CRC32-based checksum, in the exact same way that MEGA does it.
+///
+/// This allows to compute a checksum for any arbitrary data and compare it to the ones of remote MEGA nodes.
+///
+/// Here is an example of how to use this function:
+/// ```rust,no_run
+/// # fn main() {
+/// let nodes = mega.fetch_own_nodes().await?;
+///
+/// let remote_checksum = {
+///     let node = nodes.get_node_by_path("/Root/some-remote-file.txt").unwrap();
+///     node.checksum().unwrap()
+/// };
+///
+/// let local_checksum = {
+///     let file = File::open("some-local-file.txt").await?;
+///     let size = file.metadata().await?.len();
+///     mega::compute_checksum(file, size).await?
+/// };
+///
+/// if local_checksum == remote_checksum {
+///     println!("OK ! (the checksums are identical)");
+/// } else {
+///     println!("FAILED ! (the checksums differ)");
+/// }
+/// # }
+/// ```
+pub async fn compute_sparse_checksum<R: AsyncRead>(reader: R, size: usize) -> Result<[u8; 16]> {
+    const MAXFULL: usize = 8192;
+
+    const CRC_SIZE: usize = 16;
+    const BLOCK_SIZE: usize = CRC_SIZE * 4;
+
+    match size {
+        size if size <= 16 => {
+            // tiny file: checksum is simply the file's content verbatim.
+            let mut checksum = [0u8; 16];
+            pin!(reader).read_exact(&mut checksum).await?;
+            Ok(checksum)
+        }
+        size if size <= MAXFULL => {
+            // small file: full coverage, four full CRC32s.
+            let mut buffer = vec![0u8; size];
+            pin!(reader).read_exact(&mut buffer).await?;
+
+            let mut checksum = [0u8; 16];
+            for i in 0..4 {
+                let crc = {
+                    let begin = i * size / 4;
+                    let end = (i + 1) * size / 4;
+                    crc32fast::hash(&buffer[begin..end])
+                };
+
+                let begin = i * 4;
+                checksum[begin..(begin + 4)].copy_from_slice(&crc.to_be_bytes());
+            }
+
+            Ok(checksum)
+        }
+        size => {
+            // large file: sparse coverage, four sparse CRC32s.
+            let mut reader = pin!(reader);
+
+            let mut block = [0u8; BLOCK_SIZE];
+            let blocks = MAXFULL / (BLOCK_SIZE * 4);
+
+            let mut checksum = [0u8; 16];
+
+            let mut cursor = 0;
+            for idx in 0..4 {
+                let mut hasher = crc32fast::Hasher::new();
+                for blk in 0..blocks {
+                    let offset = (size - BLOCK_SIZE) * (idx * blocks + blk) / (4 * blocks - 1);
+                    let gap = u64::try_from(offset - cursor).unwrap();
+                    futures::io::copy((&mut reader).take(gap), &mut futures::io::sink()).await?;
+                    (&mut reader).read_exact(&mut block).await?;
+                    hasher.update(&block);
+                    cursor = offset + BLOCK_SIZE;
+                }
+
+                let crc = hasher.finalize();
+
+                let begin = idx * 4;
+                checksum[begin..(begin + 4)].copy_from_slice(&crc.to_be_bytes());
+            }
+
+            Ok(checksum)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1256,7 +1256,7 @@ impl Client {
         let file_attr = NodeAttributes {
             name: name.to_string(),
             fingerprint: None,
-            modified_at: Some(Utc::now().timestamp()),
+            modified_at: None,
             other: HashMap::default(),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1303,15 +1303,15 @@ impl Client {
     /// Renames a node.
     pub async fn rename_node(&self, node: &Node, name: &str) -> Result<()> {
         let attributes = {
-            let modified_at = Utc::now().timestamp();
-            let fingerprint = node
-                .checksum
-                .map(|checksum| NodeFingerprint::new(checksum, modified_at).serialize());
+            let fingerprint =
+                (node.checksum.zip(node.modified_at)).map(|(checksum, modified_at)| {
+                    NodeFingerprint::new(checksum, modified_at.timestamp()).serialize()
+                });
 
             NodeAttributes {
                 name: name.to_string(),
                 fingerprint,
-                modified_at: Some(modified_at),
+                modified_at: Some(0),
                 other: HashMap::default(),
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -988,7 +988,7 @@ impl Client {
             NodeAttributes {
                 name: name.to_string(),
                 fingerprint: Some(fingerprint.serialize()),
-                modified_at: Some(last_modified),
+                modified_at: None,
                 other: HashMap::default(),
             }
         };
@@ -1258,7 +1258,7 @@ impl Client {
         let file_attr = NodeAttributes {
             name: name.to_string(),
             fingerprint: None,
-            modified_at: Some(0),
+            modified_at: None,
             other: HashMap::default(),
         };
 
@@ -1313,7 +1313,7 @@ impl Client {
             NodeAttributes {
                 name: name.to_string(),
                 fingerprint,
-                modified_at: Some(0),
+                modified_at: None,
                 other: HashMap::default(),
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1258,7 +1258,7 @@ impl Client {
         let file_attr = NodeAttributes {
             name: name.to_string(),
             fingerprint: None,
-            modified_at: None,
+            modified_at: Some(0),
             other: HashMap::default(),
         };
 

--- a/tests/upload_and_download.rs
+++ b/tests/upload_and_download.rs
@@ -39,6 +39,7 @@ async fn upload_and_download_test() {
         "mega-rs-test-file.txt",
         size.try_into().unwrap(),
         uploaded.as_bytes(),
+        mega::LastModified::Now,
     )
     .await
     .expect("could not upload test file");


### PR DESCRIPTION
This PR adds support for the handling of the `c` field of the node's attributes, which essentially acts as a fingerprinting measure for file nodes.  

It can be used to quickly determine whether the file has been modified, without having to download any of its contents.  

It essentially consists of a serialization of both:
- the UNIX timestamp of the last modification date.
- a sparse CRC32-based checksum of the current contents of the node.

In this PR, we now support both the deserialization of these fingerprints, but also their serialization along with the automatic generation of these checksum for new file uploads.  
This fingerprint is also updated when moving a node or renaming a node.  

For completeness, we also support the `t` attribute, ~~which we automatically update as well~~ (only `upload_node` changes the last modification dates, renaming or moving a node does not count as an actual file modification).

The checksum is currently not verified during when downloading a node, as a MAC is already used for similar purposes, but we expose the checksum generation routine (`mega::compute_sparse_checksum`) to users so that they may perform these additional checks or any other operation which might involve these checksums.

Users can now access:
- the node's checksum using the new `Node::sparse_checksum`  method
- the node's last modification date using the new `Node::modified_at` method.

We also introduce a new `mega::LastModified` enum, along with changing `Client::upload_node` to accept an additional `last_modified: LastModified` argument, to allow users to set a specific last modification date if they so choose.  

Using an enum like `LastModified` instead of directly accepting a `DateTime<Utc>` allows users to not have to necessarily take a direct dependency on `chrono`, if they choose the `LastModified::Now` variant.

**Closes #1.**