### PR TITLE
Support for Server-to-Client events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `Node::modified_at`.
-- Added `Node::aes_key`.
-- Added `Node::aes_iv`.
-- Added `Node::condensed_mac`.
-- Added `Node::sparse_checksum`.
+- Added `Node::owner` getter method.
+- Added `Node::modified_at` getter method.
+- Added `Node::aes_key` getter method.
+- Added `Node::aes_iv` getter method.
+- Added `Node::condensed_mac` getter method.
+- Added `Node::sparse_checksum` getter method.
 - Added `compute_sparse_checksum` standalone function.
 - Added `compute_condensed_mac` standalone function.
 - Added `LastModified` enum.
+- Added `Event` enum.
+- Added `EventBatch` struct.
+- Added `EventNode` struct.
+- Added `EventNodeAttributes` struct.
+- Added `Client::poll_event` method.
+- Added `Client::wait_event` method.
+- Added `Nodes::apply_events` method.
 
 ### Changed
 
@@ -36,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed last modification dates being overwritten when renaming nodes.
 
 ### Removed
+
+- Removed `Clone` impl for `Node`.
 
 [0.4.1] - 2023-05-25
 --------------------

--- a/README.md
+++ b/README.md
@@ -1,34 +1,63 @@
-MEGA API Rust Client
-====================
+<div align=center><h1>mega-rs</h1></div>
+<div align=center><strong>An API client library for interacting with MEGA</strong></div>
 
-<!-- [![CI](https://github.com/Hirevo/mega-rs/actions/workflows/ci.yaml/badge.svg)](https://github.com/Hirevo/mega-rs/actions/workflows/ci.yaml) -->
-[![version](https://img.shields.io/crates/v/mega)](https://crates.io/crates/mega)
-[![docs](https://img.shields.io/docsrs/mega)](https://docs.rs/mega)
-[![license](https://img.shields.io/crates/l/mega)](https://github.com/Hirevo/mega-rs#license)
+<br />
 
-This is an API client library for interacting with MEGA's API using Rust.
+<div align="center">
+  <!-- crate version -->
+  <a href="https://crates.io/crates/mega">
+    <img src="https://img.shields.io/crates/v/mega" alt="crates.io version" />
+  </a>
+  <!-- crate downloads -->
+  <a href="https://crates.io/crates/mega">
+    <img src="https://img.shields.io/crates/d/mega" alt="crates.io download count" />
+  </a>
+  <!-- crate docs -->
+  <a href="https://docs.rs/mega">
+    <img src="https://img.shields.io/docsrs/mega" alt="docs.rs docs" />
+  </a>
+  <!-- crate license -->
+  <a href="https://github.com/Hirevo/mega-rs#license">
+    <img src="https://img.shields.io/crates/l/mega" alt="crate license" />
+  </a>
+</div>
+
+About
+-----
+
+This is an API client library for interacting with MEGA's API using Rust.  
+
+This library aims to implement most (if not all) interactions with MEGA's API in pure Rust.  
+
+This allows to Rust applications to access MEGA without needing to depend on the [MEGAcmd] command-line tool being installed on the host system.  
+
+It can also allow for more fine-grained control over how the operations are carried-out, like downloading nodes concurrently.  
+
+[MEGAcmd]: https://github.com/meganz/MEGAcmd
 
 Features
 --------
 
 - [x] Login with MEGA
   - [x] MFA support
+  - [ ] Session serialization
+  - [ ] Session resumption (deserialization)
 - [x] Get storage quotas
 - [x] Listing nodes
 - [x] Downloading nodes
 - [x] Uploading nodes
 - [x] Creating folders
 - [x] Renaming, moving and deleting nodes
+- [ ] Chunked file downloads (downloading/uploading multiple chunks in parallel)
 - [x] Timeout support
 - [x] Retries (exponential-backoff) support
-- [ ] Parallel connections (downloading/uploading multiple file chunks in parallel)
 - [x] Downloading thumbnails and preview images
 - [x] Uploading thumbnails and preview images
-- [x] Shared links support
-  - [x] Downloading from shared links
-  - [ ] Uploading to shared folders
-  - [ ] Create shared links to owned nodes
-- [ ] Server-to-Client events support
+- [x] Support for public shared links
+- [ ] Support for password-protected shared links
+- [ ] Create public shared links to owned nodes
+- [ ] Uploading to shared private folders
+- [x] Server-to-Client events support
 
 Examples
 --------

--- a/examples/tree_listing.rs
+++ b/examples/tree_listing.rs
@@ -17,12 +17,13 @@ fn construct_tree_node(nodes: &mega::Nodes, node: &mega::Node) -> StringTreeNode
     folders.sort_unstable_by_key(|node| node.name());
     files.sort_unstable_by_key(|node| node.name());
 
+    let label = format!("(H:{0}) {1}", node.handle(), node.name());
     let children = std::iter::empty()
         .chain(folders)
         .chain(files)
         .map(|node| construct_tree_node(nodes, node));
 
-    StringTreeNode::with_child_nodes(node.name().to_string(), children)
+    StringTreeNode::with_child_nodes(label, children)
 }
 
 async fn run(mega: &mut mega::Client, distant_file_path: Option<&str>) -> mega::Result<()> {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -418,7 +418,7 @@ pub struct FetchNodesResponse {
     /// Additional data about the nodes' owners.
     #[serde(rename = "u")]
     pub user: Option<Vec<FileUser>>,
-    /// TODO
+    /// Event cursor for server-to-client events.
     #[serde(rename = "sn")]
     pub sn: String,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     /// Could not get a meaningful response after maximum retries.
     #[error("could not get a meaningful response after maximum retries")]
     MaxRetriesReached,
+    /// The involved event cursors do not match, continuing would result in inconsistencies.
+    #[error("the involved event cursors do not match, continuing would result in inconsistencies")]
+    EventCursorMismatch,
     /// Reqwest error.
     #[cfg(feature = "reqwest")]
     #[error("reqwest error: {0}")]

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,129 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventResponseNodes {
+    #[serde(rename = "f")]
+    pub files: Vec<crate::commands::FileNode>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeCreatedEventResponse {
+    /// The idempotence token of the operation for which this event is emitted.
+    #[serde(rename = "i")]
+    pub i: Option<String>,
+    /// The owner of the nodes.
+    #[serde(rename = "ou")]
+    pub owner: String,
+    /// The batch of created nodes.
+    #[serde(rename = "t")]
+    pub nodes: EventResponseNodes,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeUpdatedEventResponse {
+    /// The idempotence token of the operation for which this event is emitted.
+    #[serde(rename = "i")]
+    pub i: Option<String>,
+    /// The handle of the updated node.
+    #[serde(rename = "n")]
+    pub handle: String,
+    /// The user handle of the new owner of the node.
+    #[serde(rename = "u")]
+    pub owner: String,
+    /// The new encoded attributes for the node.
+    #[serde(rename = "at")]
+    pub attr: String,
+    // /// The updated key for the node.
+    // ///
+    // /// Key updates are no longer supported by MEGA, but still transmitted for backwards compatibility.
+    // #[serde(rename = "k")]
+    // pub key: String,
+    /// The new creation date for the node.
+    #[serde(rename = "ts")]
+    pub ts: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeDeletedEventResponse {
+    /// The idempotence token of the operation for which this event is emitted.
+    #[serde(rename = "i")]
+    pub i: Option<String>,
+    /// The handle of the deleted node.
+    #[serde(rename = "n")]
+    pub handle: String,
+    /// This field is set to `1` if this event is due to a moved node.
+    #[serde(rename = "m")]
+    pub mov: Option<i32>,
+    /// The owner of the deleted node.
+    #[serde(rename = "ou")]
+    pub owner: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UnknownEventResponse {
+    #[serde(flatten)]
+    pub other: HashMap<String, json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "a")]
+pub enum EventResponseKind {
+    /// One (or more) new nodes have been created.
+    #[serde(rename = "t")]
+    NodeCreated(NodeCreatedEventResponse),
+    /// A node's attributes have been updated.
+    #[serde(rename = "u")]
+    NodeUpdated(NodeUpdatedEventResponse),
+    /// One node (or more, if it had children) have been deleted.
+    #[serde(rename = "d")]
+    NodeDeleted(NodeDeletedEventResponse),
+    // TODO: "s": share addition/update/revocation
+    // TODO: "s2": share addition/update/revocation
+    // TODO: "c": contact addition/update
+    // TODO: "k": crypto key request
+    // TODO: "fa": file attribute update
+    // TODO: "ua": user attribute update
+    // TODO: "psts": account updated
+    // TODO: "ipc": incoming pending contact request (to us)
+    // TODO: "opc": outgoing pending contact request (from us)
+    // TODO: "upci": incoming pending contact request update (accept/deny/ignore)
+    // TODO: "upco": outgoing pending contact request update (from them, accept/deny/ignore)
+    // TODO: "ph": public links handles
+    // TODO: "se": set email
+    // TODO: "mcc": chat creation / peer's invitation / peer's removal
+    // TODO: "mcna": granted / revoked access to a node
+    // TODO: "uac": user access control
+    #[serde(other)]
+    UnknownEvent,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventResponse {
+    #[serde(flatten)]
+    pub kind: EventResponseKind,
+    #[serde(flatten)]
+    pub other: HashMap<String, json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventBatchResponseReady {
+    #[serde(rename = "sn")]
+    pub sn: String,
+    #[serde(rename = "a")]
+    pub events: Vec<json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventBatchResponseWait {
+    #[serde(rename = "w")]
+    pub wait_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EventBatchResponse {
+    Ready(EventBatchResponseReady),
+    Wait(EventBatchResponseWait),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,7 +419,7 @@ impl Client {
                         aes_key,
                         aes_iv,
                         condensed_mac,
-                        checksum: fingerprint.map(|it| it.checksum),
+                        sparse_checksum: fingerprint.map(|it| it.checksum),
                         created_at: Some(Utc.timestamp_opt(file.ts, 0).unwrap()),
                         modified_at,
                         download_id: None,
@@ -451,7 +451,7 @@ impl Client {
                         aes_key: <_>::default(),
                         aes_iv: None,
                         condensed_mac: None,
-                        checksum: None,
+                        sparse_checksum: None,
                         created_at: Some(Utc.timestamp_opt(file.ts, 0).unwrap()),
                         modified_at: None,
                         download_id: None,
@@ -478,7 +478,7 @@ impl Client {
                         aes_key: <_>::default(),
                         aes_iv: None,
                         condensed_mac: None,
-                        checksum: None,
+                        sparse_checksum: None,
                         created_at: Some(Utc.timestamp_opt(file.ts, 0).unwrap()),
                         modified_at: None,
                         download_id: None,
@@ -505,7 +505,7 @@ impl Client {
                         aes_key: <_>::default(),
                         aes_iv: None,
                         condensed_mac: None,
-                        checksum: None,
+                        sparse_checksum: None,
                         created_at: Some(Utc.timestamp_opt(file.ts, 0).unwrap()),
                         modified_at: None,
                         download_id: None,
@@ -620,7 +620,7 @@ impl Client {
                     aes_key,
                     aes_iv: Some(aes_iv),
                     condensed_mac: Some(condensed_mac),
-                    checksum: fingerprint.map(|it| it.checksum),
+                    sparse_checksum: fingerprint.map(|it| it.checksum),
                     created_at: None,
                     modified_at,
                     download_id: Some(node_id.clone()),
@@ -745,7 +745,7 @@ impl Client {
                                 aes_key,
                                 aes_iv,
                                 condensed_mac,
-                                checksum: fingerprint.map(|it| it.checksum),
+                                sparse_checksum: fingerprint.map(|it| it.checksum),
                                 created_at: Some(Utc.timestamp_opt(file.ts, 0).unwrap()),
                                 modified_at,
                                 download_id: Some(node_id.clone()),
@@ -1330,7 +1330,7 @@ impl Client {
     pub async fn rename_node(&self, node: &Node, name: &str) -> Result<()> {
         let attributes = {
             let fingerprint =
-                (node.checksum.zip(node.modified_at)).map(|(checksum, modified_at)| {
+                (node.sparse_checksum.zip(node.modified_at)).map(|(checksum, modified_at)| {
                     NodeFingerprint::new(checksum, modified_at.timestamp()).serialize()
                 });
 
@@ -1518,7 +1518,7 @@ impl Client {
                         handle: event.handle,
                         name: attrs.name,
                         owner: event.owner,
-                        checksum: fingerprint.map(|it| it.checksum),
+                        sparse_checksum: fingerprint.map(|it| it.checksum),
                         created_at: Some(Utc.timestamp_opt(event.ts, 0).unwrap()),
                         modified_at,
                     };
@@ -1600,7 +1600,7 @@ impl Client {
                         handle: event.handle,
                         name: attrs.name,
                         owner: event.owner,
-                        checksum: fingerprint.map(|it| it.checksum),
+                        sparse_checksum: fingerprint.map(|it| it.checksum),
                         created_at: Some(Utc.timestamp_opt(event.ts, 0).unwrap()),
                         modified_at,
                     };
@@ -1937,7 +1937,7 @@ pub struct EventNodeAttributes {
     /// The user handle of the owner of this node.
     pub(crate) owner: String,
     /// The sparse checksum of the node.
-    pub(crate) checksum: Option<[u8; 16]>,
+    pub(crate) sparse_checksum: Option<[u8; 16]>,
     /// The creation date of the node.
     pub(crate) created_at: Option<DateTime<Utc>>,
     /// The last modification date of the node.
@@ -1961,8 +1961,8 @@ impl EventNodeAttributes {
     }
 
     /// Returns the new sparse CRC32-based checksum of the node.
-    pub fn checksum(&self) -> Option<&[u8; 16]> {
-        self.checksum.as_ref()
+    pub fn sparse_checksum(&self) -> Option<&[u8; 16]> {
+        self.sparse_checksum.as_ref()
     }
 
     /// Returns the new last modified date of the node.
@@ -2032,7 +2032,7 @@ pub struct Node {
     /// The full-coverage condensed MAC of the node.
     pub(crate) condensed_mac: Option<[u8; 8]>,
     /// The sparse checksum of the node.
-    pub(crate) checksum: Option<[u8; 16]>,
+    pub(crate) sparse_checksum: Option<[u8; 16]>,
     /// The creation date of the node.
     pub(crate) created_at: Option<DateTime<Utc>>,
     /// The last modification date of the node.
@@ -2113,7 +2113,7 @@ impl Node {
 
     /// Returns the sparse CRC32-based checksum of the node.
     pub fn sparse_checksum(&self) -> Option<&[u8; 16]> {
-        self.checksum.as_ref()
+        self.sparse_checksum.as_ref()
     }
 
     /// Returns whether this node has a associated thumbnail.
@@ -2286,7 +2286,7 @@ impl Nodes {
             aes_key: node.aes_key,
             aes_iv: node.aes_iv,
             condensed_mac: node.condensed_mac,
-            checksum: node.checksum,
+            sparse_checksum: node.checksum,
             created_at: node.created_at,
             modified_at: node.modified_at,
             download_id: node.download_id,
@@ -2329,7 +2329,7 @@ impl Nodes {
 
         node.name = attrs.name;
         node.owner = attrs.owner;
-        node.checksum = attrs.checksum;
+        node.sparse_checksum = attrs.sparse_checksum;
         node.created_at = attrs.created_at;
         node.modified_at = attrs.modified_at;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1998,7 +1998,7 @@ pub struct EventBatch {
 }
 
 impl EventBatch {
-    pub fn new(events: Vec<Event>, from: String, to: String) -> Self {
+    pub(crate) fn new(events: Vec<Event>, from: String, to: String) -> Self {
         Self { events, from, to }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1927,17 +1927,7 @@ impl EventNode {
     }
 }
 
-/// A MEGA-emitted event.
-#[derive(Debug, PartialEq)]
-pub enum Event {
-    /// A new node has been created.
-    NodeCreated { nodes: Vec<EventNode> },
-    /// An existing node has been updated.
-    NodeUpdated { attrs: EventNodeAttributes },
-    /// A node has been deleted.
-    NodeDeleted { handle: String },
-}
-
+/// Represents the updated attributes of a node, as part of an [`Event`].
 #[derive(Debug, PartialEq)]
 pub struct EventNodeAttributes {
     /// The handle of the node.
@@ -1984,6 +1974,17 @@ impl EventNodeAttributes {
     pub fn created_at(&self) -> Option<DateTime<Utc>> {
         self.created_at
     }
+}
+
+/// A MEGA-emitted event.
+#[derive(Debug, PartialEq)]
+pub enum Event {
+    /// A new node has been created.
+    NodeCreated { nodes: Vec<EventNode> },
+    /// An existing node has been updated.
+    NodeUpdated { attrs: EventNodeAttributes },
+    /// A node has been deleted.
+    NodeDeleted { handle: String },
 }
 
 /// A batch of MEGA-emitted events.

--- a/tests/event_updates.rs
+++ b/tests/event_updates.rs
@@ -1,0 +1,154 @@
+//!
+//! Integration test for using events to update local nodes and chain operations.
+//!
+
+use std::env;
+
+use rand::distributions::{Alphanumeric, DistString};
+
+#[tokio::test]
+async fn event_updates_test() {
+    let email = env::var("MEGA_EMAIL").expect("missing MEGA_EMAIL environment variable");
+    let password = env::var("MEGA_PASSWORD").expect("missing MEGA_PASSWORD environment variable");
+    let mfa = env::var("MEGA_MFA").ok();
+
+    let http_client = reqwest::Client::new();
+    let mut mega = mega::Client::builder().build(http_client).unwrap();
+
+    mega.login(&email, &password, mfa.as_deref())
+        .await
+        .expect("could not log in to MEGA");
+
+    let mut nodes = mega
+        .fetch_own_nodes()
+        .await
+        .expect("could not fetch own nodes");
+
+    let root = nodes
+        .get_node_by_path("/Root/mega-rs-tests")
+        .expect("could not find Cloud Drive root");
+
+    let cloud_drive_handle = root.handle().to_string();
+
+    let uploaded = {
+        let mut rng = rand::thread_rng();
+        Alphanumeric.sample_string(&mut rng, 1024)
+    };
+
+    let file_name = {
+        let mut rng = rand::thread_rng();
+        format!(
+            "mega-rs-test-file-{0}.txt",
+            Alphanumeric.sample_string(&mut rng, 10),
+        )
+    };
+
+    let size = uploaded.len();
+
+    mega.upload_node(
+        root,
+        file_name.as_str(),
+        size.try_into().unwrap(),
+        uploaded.as_bytes(),
+        mega::LastModified::Now,
+    )
+    .await
+    .expect("could not upload test file");
+
+    let uploaded_handle = loop {
+        let batch = mega
+            .wait_events(&nodes)
+            .await
+            .expect("could not fetch MEGA events");
+
+        let maybe_uploaded_handle = batch.events().iter().find_map(|event| {
+            let mega::Event::NodeCreated { nodes } = event else {
+                return None;
+            };
+
+            nodes.iter().find_map(|node| {
+                (node.parent() == Some(cloud_drive_handle.as_str()) && node.name() == file_name)
+                    .then(|| node.handle().to_string())
+            })
+        });
+
+        nodes
+            .apply_events(batch)
+            .expect("could not apply events to local nodes");
+
+        if let Some(uploaded_handle) = maybe_uploaded_handle {
+            break uploaded_handle;
+        }
+    };
+
+    let node = nodes
+        .get_node_by_handle(&uploaded_handle)
+        .expect("could not find test file node after upload");
+
+    let mut downloaded = Vec::default();
+    mega.download_node(node, &mut downloaded)
+        .await
+        .expect("could not download test file");
+
+    assert_eq!(uploaded.as_bytes(), downloaded.as_slice());
+
+    let new_file_name = {
+        let mut rng = rand::thread_rng();
+        format!(
+            "mega-rs-test-file-{0}.txt",
+            Alphanumeric.sample_string(&mut rng, 10),
+        )
+    };
+
+    mega.rename_node(node, &new_file_name)
+        .await
+        .expect("could not rename node");
+
+    loop {
+        let batch = mega
+            .wait_events(&nodes)
+            .await
+            .expect("could not fetch MEGA events");
+
+        let found_event = batch.events().iter().any(|event| {
+            matches!(event, mega::Event::NodeUpdated { attrs } if attrs.handle() == uploaded_handle.as_str())
+        });
+
+        nodes
+            .apply_events(batch)
+            .expect("could not apply events to local nodes");
+
+        if found_event {
+            break;
+        }
+    }
+
+    let node = nodes
+        .get_node_by_handle(&uploaded_handle)
+        .expect("could not find test file node after rename");
+
+    mega.delete_node(node)
+        .await
+        .expect("could not delete test file");
+
+    loop {
+        let batch = mega
+            .wait_events(&nodes)
+            .await
+            .expect("could not fetch MEGA events");
+
+        let found_event = batch.events().iter().any(|event| {
+            matches!(event, mega::Event::NodeDeleted { handle } if handle.as_str() == uploaded_handle.as_str())
+        });
+
+        nodes
+            .apply_events(batch)
+            .expect("could not apply events to local nodes");
+
+        if found_event {
+            break;
+        }
+    }
+
+    mega.logout().await.expect("could not log out from MEGA");
+}

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -8,11 +8,12 @@ use std::env;
 async fn login_and_logout_test() {
     let email = env::var("MEGA_EMAIL").expect("missing MEGA_EMAIL environment variable");
     let password = env::var("MEGA_PASSWORD").expect("missing MEGA_PASSWORD environment variable");
+    let mfa = env::var("MEGA_MFA").ok();
 
     let http_client = reqwest::Client::new();
     let mut mega = mega::Client::builder().build(http_client).unwrap();
 
-    mega.login(&email, &password, None)
+    mega.login(&email, &password, mfa.as_deref())
         .await
         .expect("could not log in to MEGA");
 

--- a/tests/upload_and_download.rs
+++ b/tests/upload_and_download.rs
@@ -12,11 +12,12 @@ pub const BASE_PATH: &str = "/Root/mega-rs-tests";
 async fn upload_and_download_test() {
     let email = env::var("MEGA_EMAIL").expect("missing MEGA_EMAIL environment variable");
     let password = env::var("MEGA_PASSWORD").expect("missing MEGA_PASSWORD environment variable");
+    let mfa = env::var("MEGA_MFA").ok();
 
     let http_client = reqwest::Client::new();
     let mut mega = mega::Client::builder().build(http_client).unwrap();
 
-    mega.login(&email, &password, None)
+    mega.login(&email, &password, mfa.as_deref())
         .await
         .expect("could not log in to MEGA");
 


### PR DESCRIPTION
This PR adds support for MEGA's server-to-client events.  

This allows to maintain the local node tree (the `Nodes` struct) up-to-date, even as the remote tree changes by asking MEGA about the what changed since the time of our last fetch and applying the deltas on our own local tree.  

Here is an example of how to make use of some of this new feature:

```rust
// This is our initial fetch of nodes from MEGA:
let mut nodes = mega.fetch_own_nodes().await?;
//  ^^^ notice how `nodes` is now mutable, since we'll be updating it later.

// Some time passes ...

// We fetch to see if there is some new node events from MEGA since our last update:
if let Some(batch) = mega.poll_events(&nodes).await? {
    // Some events were delivered to us !

    // We can inspect them, if we are expecting something specific:
    for event in batch.events() {
        Event::NodeCreated { nodes } => {
            // New nodes were created !
            // `nodes` is of type `Vec<EventNode>`.
            todo!()
        }
        Event::NodeUpdated { attrs } => {
            // A node's attributes have been updated !
            // `attrs` is of type `EventNodeAttributes`.
            todo!()
        }
        Event::NodeDeleted { handle } => {
            // A node has been deleted !
            // `handle` is of type `String`.
            todo!()
        }
    }

    // We can then apply these events to our local node tree to bring it up-to-date with MEGA's servers:
    nodes.apply_events(batch)?;
}

// We can also indefinitely (and efficiently) wait for at least one MEGA event to be delivered:
let batch = mega.wait_events(&nodes).await?;
```

Checks are implemented to make sure events are applied in the correct order.  
This is done using a event sequence identifier that MEGA itself delivers with each batch of events.  

It should therefore be impossible for `Nodes` to diverge from MEGA's remote (up-to-date) tree.  
The worst the local `Nodes` can be from MEGA's tree is being out-of-date, but never wrongly updated due to skipped events or out-of-order application of events.  