### PR TITLE
Removed `Nodes::iter_mut`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed `Clone` impl for `Node`.
+- Removed `Nodes::iter_mut` method.
 
 [0.4.1] - 2023-05-25
 --------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2231,11 +2231,6 @@ impl Nodes {
         self.nodes.values()
     }
 
-    /// Creates a mutably-borrowing iterator over the nodes.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Node> {
-        self.nodes.values_mut()
-    }
-
     pub fn apply_events(&mut self, events: EventBatch) -> Result<()> {
         if self.event_cursor != events.from {
             return Err(Error::EventCursorMismatch);


### PR DESCRIPTION
This PR removes the `Nodes::iter_mut` method.

Since we do not expose any mutable field or method on `Node` currently, it seems like this method is both not needed and not recommended since the arbitrary manipulation of nodes can result in unpredictable behaviour, especially now that the node tree can be updated using server-to-client events from MEGA.