### PR TITLE
Support for session resumption and serialization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,4 +32,5 @@ jobs:
           MEGA_EMAIL: ${{ secrets.MEGA_EMAIL }}
           MEGA_PASSWORD: ${{ secrets.MEGA_PASSWORD }}
           MEGA_PUBLIC_URL: ${{ secrets.MEGA_PUBLIC_URL }}
+          MEGA_SESSION: ${{ secrets.MEGA_SESSION }}
         run: cargo test --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Client::resume_session` method.
+- Added `Client::serialize_session` method.
+
 ### Changed
+
+- Added `#[non_exhaustive]` attribute on `Error` enum.
+- Changed `Error` variants from tuples to named fields.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Features
 
 - [x] Login with MEGA
   - [x] MFA support
-  - [ ] Session serialization
-  - [ ] Session resumption (deserialization)
+  - [x] Session resumption (deserialization)
+  - [x] Session serialization
 - [x] Get storage quotas
 - [x] Listing nodes
 - [x] Downloading nodes

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,10 +28,16 @@ pub enum Error {
     InvalidResponseFormat,
     /// Invalid response format.
     #[error("missing response field: `{field}`")]
-    MissingResponseField { field: &'static str },
+    MissingResponseField {
+        /// The name of the missing field.
+        field: &'static str,
+    },
     /// Unknown user login version.
     #[error("unknown user login version: `{version}`")]
-    UnknownUserLoginVersion { version: i32 },
+    UnknownUserLoginVersion {
+        /// The encountered login version.
+        version: i32,
+    },
     /// Failed condensed MAC verification.
     #[error("condensed MAC mismatch")]
     CondensedMacMismatch,
@@ -51,72 +57,84 @@ pub enum Error {
     #[cfg(feature = "reqwest")]
     #[error("`reqwest` error: {source}")]
     ReqwestError {
+        /// The source `reqwest` error.
         #[from]
         source: reqwest::Error,
     },
     /// URL parse error.
     #[error("URL parse error: {source}")]
     UrlError {
+        /// The source `url` error.
         #[from]
         source: url::ParseError,
     },
     /// JSON error.
     #[error("JSON error: {source}")]
     JsonError {
+        /// The source `serde_json` error.
         #[from]
         source: json::Error,
     },
     /// Base64 encode error.
     #[error("base64 encode error: {source}")]
     Base64EncodeError {
+        /// The source `base64` encode error.
         #[from]
         source: base64::EncodeSliceError,
     },
     /// Base64 decode error.
     #[error("base64 encode error: {source}")]
     Base64DecodeError {
+        /// The source `base64` decode error.
         #[from]
         source: base64::DecodeError,
     },
     /// PBKDF2 error.
     #[error("PBKDF2 error: {source}")]
     Pbkdf2Error {
+        /// The source `pbkdf2` error.
         #[from]
         source: pbkdf2::password_hash::Error,
     },
     /// HKDF error (invalid length).
     #[error("HKDF error: {source}")]
     HkdfInvalidLengthError {
+        /// The source `hkdf` invalid length error.
         #[from]
         source: hkdf::InvalidLength,
     },
     /// HKDF error (invalid PRK length).
     #[error("HKDF error: {source}")]
     HkdfInvalidPrkLengthError {
+        /// The source `hkdf` invalid PRK length error.
         #[from]
         source: hkdf::InvalidPrkLength,
     },
     /// AES-GCM error.
     #[error("AES-GCM error: {source}")]
     AesGcmError {
+        /// The source `aes_gcm` error.
         #[from]
         source: aes_gcm::Error,
     },
     /// MEGA error (error codes from API).
     #[error("MEGA error: {code}")]
     MegaError {
+        /// The MEGA error code.
         #[from]
         code: ErrorCode,
     },
     /// I/O error.
     #[error("IO error: {source}")]
     IoError {
+        /// The source `std::io` error.
         #[from]
         source: std::io::Error,
     },
     /// Other errors.
     #[error("other error: {source}")]
     Other {
+        /// The source error.
         #[from]
         source: Box<dyn std::error::Error + Send + Sync>,
     },

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,11 +5,15 @@ use thiserror::Error;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// The main error type for this library.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum Error {
     /// Missing user session.
     #[error("missing user session (consider logging in first)")]
     MissingUserSession,
+    /// Invalid session kind.
+    #[error("invalid session kind")]
+    InvalidSessionKind,
     /// Invalid (or unsupported) public URL format.
     #[error("invalid (or unsupported) public URL format")]
     InvalidPublicUrlFormat,
@@ -22,12 +26,15 @@ pub enum Error {
     /// Invalid response format.
     #[error("invalid response format")]
     InvalidResponseFormat,
+    /// Invalid response format.
+    #[error("missing response field: `{field}`")]
+    MissingResponseField { field: &'static str },
     /// Unknown user login version.
-    #[error("unknown user login version: {0}")]
-    UnknownUserLoginVersion(i32),
-    /// Failed MAC verification.
-    #[error("failed MAC verification")]
-    MacMismatch,
+    #[error("unknown user login version: `{version}`")]
+    UnknownUserLoginVersion { version: i32 },
+    /// Failed condensed MAC verification.
+    #[error("condensed MAC mismatch")]
+    CondensedMacMismatch,
     /// Failed to find node.
     #[error("failed to find node")]
     NodeNotFound,
@@ -42,41 +49,77 @@ pub enum Error {
     EventCursorMismatch,
     /// Reqwest error.
     #[cfg(feature = "reqwest")]
-    #[error("reqwest error: {0}")]
-    ReqwestError(#[from] reqwest::Error),
+    #[error("`reqwest` error: {source}")]
+    ReqwestError {
+        #[from]
+        source: reqwest::Error,
+    },
     /// URL parse error.
-    #[error("URL parse error: {0}")]
-    UrlError(#[from] url::ParseError),
+    #[error("URL parse error: {source}")]
+    UrlError {
+        #[from]
+        source: url::ParseError,
+    },
     /// JSON error.
-    #[error("JSON error: {0}")]
-    JsonError(#[from] json::Error),
+    #[error("JSON error: {source}")]
+    JsonError {
+        #[from]
+        source: json::Error,
+    },
     /// Base64 encode error.
-    #[error("base64 encode error: {0}")]
-    Base64EncodeError(#[from] base64::EncodeSliceError),
+    #[error("base64 encode error: {source}")]
+    Base64EncodeError {
+        #[from]
+        source: base64::EncodeSliceError,
+    },
     /// Base64 decode error.
-    #[error("base64 encode error: {0}")]
-    Base64DecodeError(#[from] base64::DecodeError),
+    #[error("base64 encode error: {source}")]
+    Base64DecodeError {
+        #[from]
+        source: base64::DecodeError,
+    },
     /// PBKDF2 error.
-    #[error("PBKDF2 error: {0}")]
-    Pbkdf2Error(#[from] pbkdf2::password_hash::Error),
+    #[error("PBKDF2 error: {source}")]
+    Pbkdf2Error {
+        #[from]
+        source: pbkdf2::password_hash::Error,
+    },
     /// HKDF error (invalid length).
-    #[error("HKDF error: {0}")]
-    HkdfInvalidLengthError(#[from] hkdf::InvalidLength),
+    #[error("HKDF error: {source}")]
+    HkdfInvalidLengthError {
+        #[from]
+        source: hkdf::InvalidLength,
+    },
     /// HKDF error (invalid PRK length).
-    #[error("HKDF error: {0}")]
-    HkdfInvalidPrkLengthError(#[from] hkdf::InvalidPrkLength),
+    #[error("HKDF error: {source}")]
+    HkdfInvalidPrkLengthError {
+        #[from]
+        source: hkdf::InvalidPrkLength,
+    },
     /// AES-GCM error.
-    #[error("AES-GCM error: {0}")]
-    AesGcmError(#[from] aes_gcm::Error),
+    #[error("AES-GCM error: {source}")]
+    AesGcmError {
+        #[from]
+        source: aes_gcm::Error,
+    },
     /// MEGA error (error codes from API).
-    #[error("MEGA error: {0}")]
-    MegaError(#[from] ErrorCode),
+    #[error("MEGA error: {code}")]
+    MegaError {
+        #[from]
+        code: ErrorCode,
+    },
     /// I/O error.
-    #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
+    #[error("IO error: {source}")]
+    IoError {
+        #[from]
+        source: std::io::Error,
+    },
     /// Other errors.
-    #[error("unknown error: {0}")]
-    Other(Box<dyn std::error::Error + Send + Sync>),
+    #[error("other error: {source}")]
+    Other {
+        #[from]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 /// Error code originating from MEGA's API.

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -9,7 +9,7 @@ use url::Url;
 #[cfg(feature = "reqwest")]
 mod reqwest;
 
-use crate::error::Error;
+use crate::error::Result;
 use crate::protocol::commands::{Request, Response};
 
 /// Stores the data representing a user's session.
@@ -19,6 +19,8 @@ pub struct UserSession {
     pub(crate) sid: String,
     /// The user's master key.
     pub(crate) key: [u8; 16],
+    /// The user's `sek`.
+    pub(crate) sek: [u8; 16],
     /// The user's handle.
     pub(crate) user_handle: String,
 }
@@ -55,10 +57,10 @@ pub trait HttpClient {
         state: &ClientState,
         requests: &[Request],
         query_params: &[(&str, &str)],
-    ) -> Result<Vec<Response>, Error>;
+    ) -> Result<Vec<Response>>;
 
     /// Initiates a simple GET request, returning the response body as a reader.
-    async fn get(&self, url: Url) -> Result<Pin<Box<dyn AsyncRead>>, Error>;
+    async fn get(&self, url: Url) -> Result<Pin<Box<dyn AsyncRead>>>;
 
     /// Initiates a simple POST request, with body and optional `content-length`, returning the response body as a reader.
     async fn post(
@@ -66,5 +68,5 @@ pub trait HttpClient {
         url: Url,
         body: Pin<Box<dyn AsyncRead + Send + Sync>>,
         content_length: Option<u64>,
-    ) -> Result<Pin<Box<dyn AsyncRead>>, Error>;
+    ) -> Result<Pin<Box<dyn AsyncRead>>>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use crate::fingerprint::NodeFingerprint;
 use crate::http::{ClientState, HttpClient, UserSession};
 use crate::protocol::commands::{Request, Response, UploadAttributes};
 use crate::protocol::events::{EventBatchResponse, EventResponse, EventResponseKind};
+use crate::protocol::{FILE_KEY_SIZE, FOLDER_KEY_SIZE, USER_KEY_SIZE, USER_SID_SIZE};
 
 pub(crate) const DEFAULT_API_ORIGIN: &str = "https://g.api.mega.co.nz/";
 
@@ -205,16 +206,18 @@ impl Client {
                 todo!()
             }
             (version, _) => {
-                return Err(Error::UnknownUserLoginVersion(version));
+                return Err(Error::UnknownUserLoginVersion { version });
             }
         };
 
+        let sek: [u8; 16] = rand::random();
+
         let request = Request::Login {
-            user: email.clone(),
-            user_handle: user_handle.clone(),
+            user: Some(email.clone()),
+            user_handle: Some(user_handle.clone()),
             si: None,
             mfa: mfa.map(|it| it.to_string()),
-            session_key: None,
+            sek: Some(BASE64_URL_SAFE_NO_PAD.encode(&sek)),
         };
         let responses = self.send_requests(&[request]).await?;
 
@@ -228,10 +231,26 @@ impl Client {
             }
         };
 
-        let mut key = BASE64_URL_SAFE_NO_PAD.decode(&response.k)?;
-        utils::decrypt_ebc_in_place(&login_key, &mut key);
+        let key: [u8; 16] = {
+            let key = (response.key.as_ref())
+                .ok_or_else(|| Error::MissingResponseField { field: "k" })?;
+            let mut key = BASE64_URL_SAFE_NO_PAD.decode(key)?;
+            utils::decrypt_ebc_in_place(&login_key, &mut key);
+            key.try_into().map_err(|_| Error::InvalidResponseFormat)?
+        };
 
-        let t = BASE64_URL_SAFE_NO_PAD.decode(&response.csid)?;
+        let sek: [u8; 16] = {
+            let sek = (response.sek.as_ref())
+                .ok_or_else(|| Error::MissingResponseField { field: "sek" })?;
+            let sek = BASE64_URL_SAFE_NO_PAD.decode(sek)?;
+            sek.try_into().map_err(|_| Error::InvalidResponseFormat)?
+        };
+
+        let t = {
+            let csid = (response.csid.as_ref())
+                .ok_or_else(|| Error::MissingResponseField { field: "csid" })?;
+            BASE64_URL_SAFE_NO_PAD.decode(csid)?
+        };
         let (m, _) = utils::get_mpi(&t);
 
         let mut privk = BASE64_URL_SAFE_NO_PAD.decode(&response.privk)?;
@@ -244,11 +263,97 @@ impl Client {
 
         self.state.session = Some(UserSession {
             sid,
-            key: key[..16].try_into().unwrap(),
+            key,
+            sek,
             user_handle: response.u.clone(),
         });
 
         Ok(())
+    }
+
+    /// Resumes a session with MEGA from its serialized representation.
+    pub async fn resume_session(&mut self, session: &str) -> Result<()> {
+        let session = BASE64_URL_SAFE_NO_PAD.decode(session)?;
+
+        match session[0] {
+            1 => {}
+            2 => {
+                // folder session, not supported.
+                return Err(Error::InvalidSessionKind);
+            }
+            _ => {
+                // unknown session kind, not supported.
+                return Err(Error::InvalidSessionKind);
+            }
+        }
+
+        let (key, sid) = session[1..].split_at(16);
+
+        let mut key: [u8; 16] = key.try_into().unwrap();
+        let sid = BASE64_URL_SAFE_NO_PAD.encode(sid);
+
+        let sek: [u8; 16] = rand::random();
+
+        let request = Request::Login {
+            user: None,
+            user_handle: None,
+            si: None,
+            mfa: None,
+            sek: Some(BASE64_URL_SAFE_NO_PAD.encode(&sek)),
+        };
+        let responses = self
+            .client
+            .send_requests(&self.state, &[request], &[("sid", sid.as_str())])
+            .await?;
+
+        let response = match responses.as_slice() {
+            [Response::Login(response)] => response,
+            [Response::Error(code)] => {
+                return Err(Error::from(*code));
+            }
+            _ => {
+                return Err(Error::InvalidResponseType);
+            }
+        };
+
+        let sek: [u8; 16] = {
+            let sek = (response.sek.as_ref())
+                .ok_or_else(|| Error::MissingResponseField { field: "sek" })?;
+            let sek = BASE64_URL_SAFE_NO_PAD.decode(sek)?;
+            sek.try_into().map_err(|_| Error::InvalidResponseFormat)?
+        };
+
+        utils::decrypt_ebc_in_place(&sek, &mut key);
+
+        self.state.session = Some(UserSession {
+            sid,
+            key,
+            sek,
+            user_handle: response.u.clone(),
+        });
+
+        Ok(())
+    }
+
+    /// Serializes the current session with MEGA.
+    pub async fn serialize_session(&self) -> Result<String> {
+        let session = self
+            .state
+            .session
+            .as_ref()
+            .ok_or(Error::MissingUserSession)?;
+
+        let mut serialized: Vec<u8> = Vec::with_capacity(1 + USER_KEY_SIZE + USER_SID_SIZE);
+        serialized.push(1);
+
+        let mut key = session.key;
+        utils::encrypt_ebc_in_place(&session.sek, &mut key);
+        serialized.extend(key);
+
+        let mut sid = BASE64_URL_SAFE_NO_PAD.decode(&session.sid)?;
+        serialized.append(&mut sid);
+
+        Ok(BASE64_URL_SAFE_NO_PAD.encode(serialized))
     }
 
     /// Logs out of the current session with MEGA.
@@ -337,8 +442,8 @@ impl Client {
 
                         // File keys are 32 bytes and folder keys are 16 bytes.
                         // Other sizes are considered invalid.
-                        if (file.kind.is_file() && file_key.len() != 32)
-                            || (!file.kind.is_file() && file_key.len() != 16)
+                        if (file.kind.is_file() && file_key.len() != FILE_KEY_SIZE)
+                            || (!file.kind.is_file() && file_key.len() != FOLDER_KEY_SIZE)
                         {
                             return None;
                         }
@@ -668,8 +773,8 @@ impl Client {
 
                                 // File keys are 32 bytes and folder keys are 16 bytes.
                                 // Other sizes are considered invalid.
-                                if (file.kind.is_file() && file_key.len() != 32)
-                                    || (!file.kind.is_file() && file_key.len() != 16)
+                                if (file.kind.is_file() && file_key.len() != FILE_KEY_SIZE)
+                                    || (!file.kind.is_file() && file_key.len() != FOLDER_KEY_SIZE)
                                 {
                                     return None;
                                 }
@@ -889,7 +994,7 @@ impl Client {
         let (_, condensed_mac) = futures::try_join!(download_future, condensed_mac_future)?;
 
         if condensed_mac != node.condensed_mac.unwrap_or_default() {
-            return Err(Error::MacMismatch);
+            return Err(Error::CondensedMacMismatch);
         }
 
         Ok(())
@@ -1021,7 +1126,7 @@ impl Client {
             BASE64_URL_SAFE_NO_PAD.encode(&buffer)
         };
 
-        let mut key = [0u8; 32];
+        let mut key = [0u8; FILE_KEY_SIZE];
         key[..16].copy_from_slice(&aes_key);
         key[16..24].copy_from_slice(&aes_iv[..8]);
         key[24..].copy_from_slice(&condensed_mac);
@@ -1459,7 +1564,7 @@ impl Client {
                 if code == ErrorCode::EAGAIN {
                     continue;
                 }
-                return Err(Error::MegaError(code));
+                return Err(Error::MegaError { code });
             } else {
                 let response = json::from_value(value)?;
                 return Ok(response);
@@ -1479,7 +1584,7 @@ impl Client {
         for event in response.events {
             if event.is_number() {
                 let code = json::from_value(event)?;
-                return Err(Error::MegaError(code));
+                return Err(Error::MegaError { code });
             }
 
             let event: EventResponse = json::from_value(event)?;
@@ -1561,7 +1666,7 @@ impl Client {
         for event in response.events {
             if event.is_number() {
                 let code = json::from_value(event)?;
-                return Err(Error::MegaError(code));
+                return Err(Error::MegaError { code });
             }
 
             let event: EventResponse = json::from_value(event)?;
@@ -1663,8 +1768,8 @@ fn construct_event_node(
 
                 // File keys are 32 bytes and folder keys are 16 bytes.
                 // Other sizes are considered invalid.
-                if (file.kind.is_file() && file_key.len() != 32)
-                    || (!file.kind.is_file() && file_key.len() != 16)
+                if (file.kind.is_file() && file_key.len() != FILE_KEY_SIZE)
+                    || (!file.kind.is_file() && file_key.len() != FOLDER_KEY_SIZE)
                 {
                     return None;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2083,12 +2083,21 @@ impl EventNodeAttributes {
 /// A MEGA-emitted event.
 #[derive(Debug, PartialEq)]
 pub enum Event {
-    /// A new node has been created.
-    NodeCreated { nodes: Vec<EventNode> },
+    /// New nodes have been created.
+    NodeCreated {
+        /// The created nodes.
+        nodes: Vec<EventNode>,
+    },
     /// An existing node has been updated.
-    NodeUpdated { attrs: EventNodeAttributes },
+    NodeUpdated {
+        /// The updated attributes for the node.
+        attrs: EventNodeAttributes,
+    },
     /// A node has been deleted.
-    NodeDeleted { handle: String },
+    NodeDeleted {
+        /// The handle of the deleted node.
+        handle: String,
+    },
 }
 
 /// A batch of MEGA-emitted events.

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -4,7 +4,7 @@ use json::Value;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::error::{Error, ErrorCode};
+use crate::error::{ErrorCode, Result};
 
 /// Represents the kind of a given node.
 #[repr(u8)]
@@ -69,14 +69,14 @@ pub enum Request {
     #[serde(rename = "us")]
     Login {
         /// The user's email address.
-        #[serde(rename = "user")]
-        user: String,
+        #[serde(rename = "user", skip_serializing_if = "Option::is_none")]
+        user: Option<String>,
         /// The user's handle.
-        #[serde(rename = "uh")]
-        user_handle: String,
+        #[serde(rename = "uh", skip_serializing_if = "Option::is_none")]
+        user_handle: Option<String>,
         /// The session key to use.
         #[serde(rename = "sek", skip_serializing_if = "Option::is_none")]
-        session_key: Option<String>,
+        sek: Option<String>,
         /// TODO
         #[serde(rename = "si", skip_serializing_if = "Option::is_none")]
         si: Option<String>,
@@ -280,9 +280,11 @@ pub struct LoginResponse {
     #[serde(rename = "ach")]
     pub ach: i32,
     #[serde(rename = "csid")]
-    pub csid: String,
+    pub csid: Option<String>,
     #[serde(rename = "k")]
-    pub k: String,
+    pub key: Option<String>,
+    #[serde(rename = "sek")]
+    pub sek: Option<String>,
     #[serde(rename = "privk")]
     pub privk: String,
     #[serde(rename = "u")]
@@ -503,7 +505,7 @@ pub struct MoveResponse {}
 pub struct DeleteResponse {}
 
 impl Request {
-    pub(crate) fn parse_response_data(&self, value: Value) -> Result<Response, Error> {
+    pub(crate) fn parse_response_data(&self, value: Value) -> Result<Response> {
         if value.is_number() {
             let code = json::from_value(value)?;
             return Ok(Response::Error(code));

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,2 +1,12 @@
 pub mod commands;
 pub mod events;
+
+/// Size of the key for a file node.
+pub const FILE_KEY_SIZE: usize = 32;
+/// Size of the key for a file node.
+pub const FOLDER_KEY_SIZE: usize = 16;
+
+/// Size of the user's key.
+pub const USER_KEY_SIZE: usize = 16;
+/// Size of the user's sid.
+pub const USER_SID_SIZE: usize = 43;

--- a/tests/session_resumption.rs
+++ b/tests/session_resumption.rs
@@ -1,0 +1,26 @@
+//!
+//! Integration test for resuming a MEGA session from its serialized representation.
+//!
+
+use std::env;
+
+#[tokio::test]
+async fn session_resumption() {
+    let session = env::var("MEGA_SESSION").expect("missing MEGA_SESSION environment variable");
+
+    let http_client = reqwest::Client::new();
+    let mut mega = mega::Client::builder().build(http_client).unwrap();
+
+    mega.resume_session(&session)
+        .await
+        .expect("could not resume session with MEGA");
+
+    let nodes = mega
+        .fetch_own_nodes()
+        .await
+        .expect("could not fetch own nodes");
+
+    nodes
+        .cloud_drive()
+        .expect("could not find Cloud Drive root node");
+}


### PR DESCRIPTION
This PR adds support for resuming and serializing sessions using the same representation that `MEGAcmd` uses in its `session` command.  

This allows one to start a session (by logging in) using `MEGAcmd` and resume it in `mega-rs`, or vice-versa.

The serialized session representation essentially consists of two parts, concatenated together and encoded using base64:
- the master key encrypted using the session key (`sek`)
- the session ID (`sid`)

We only support resuming normal "account login" sessions in this implementation.  

Public folder sessions are not supported, because accessing these folders is achieved more simply, using `Client::fetch_public_nodes`.  