### PR TITLE
Made `Client` implement `Send` and `Sync`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,7 @@ dependencies = [
  "serde_repr",
  "sha2",
  "sluice",
+ "static_assertions",
  "text_trees",
  "thiserror",
  "tokio",
@@ -1374,6 +1375,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ crc32fast = "1.3.2"
 reqwest = { version = "0.11.14", features = ["json", "stream"], optional = true }
 tokio = { version = "1.25.0", features = ["time"], optional = true }
 tokio-util = { version = "0.7.7", features = ["compat", "codec"], optional = true }
+static_assertions = "1.1.0"
 
 [features]
 default = ["reqwest"]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -50,7 +50,7 @@ pub struct ClientState {
 }
 
 #[async_trait]
-pub trait HttpClient {
+pub trait HttpClient: Send + Sync {
     /// Sends the given requests to MEGA's API and parses the responses accordingly.
     async fn send_requests(
         &self,
@@ -60,7 +60,7 @@ pub trait HttpClient {
     ) -> Result<Vec<Response>>;
 
     /// Initiates a simple GET request, returning the response body as a reader.
-    async fn get(&self, url: Url) -> Result<Pin<Box<dyn AsyncRead>>>;
+    async fn get(&self, url: Url) -> Result<Pin<Box<dyn AsyncRead + Send>>>;
 
     /// Initiates a simple POST request, with body and optional `content-length`, returning the response body as a reader.
     async fn post(
@@ -68,5 +68,5 @@ pub trait HttpClient {
         url: Url,
         body: Pin<Box<dyn AsyncRead + Send + Sync>>,
         content_length: Option<u64>,
-    ) -> Result<Pin<Box<dyn AsyncRead>>>;
+    ) -> Result<Pin<Box<dyn AsyncRead + Send>>>;
 }

--- a/src/http/reqwest.rs
+++ b/src/http/reqwest.rs
@@ -103,7 +103,7 @@ impl HttpClient for reqwest::Client {
         Err(Error::MaxRetriesReached)
     }
 
-    async fn get(&self, url: Url) -> Result<Pin<Box<dyn AsyncRead>>> {
+    async fn get(&self, url: Url) -> Result<Pin<Box<dyn AsyncRead + Send>>> {
         let stream = self
             .get(url)
             .send()
@@ -119,7 +119,7 @@ impl HttpClient for reqwest::Client {
         url: Url,
         body: Pin<Box<dyn AsyncRead + Send + Sync>>,
         content_length: Option<u64>,
-    ) -> Result<Pin<Box<dyn AsyncRead>>> {
+    ) -> Result<Pin<Box<dyn AsyncRead + Send>>> {
         let stream = FramedRead::new(body.compat(), BytesCodec::new());
         let body = Body::wrap_stream(stream);
         let stream = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use cipher::generic_array::GenericArray;
 use cipher::{BlockDecryptMut, BlockEncrypt, BlockEncryptMut, KeyInit, KeyIvInit, StreamCipher};
 use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use static_assertions::assert_impl_all;
 use url::Url;
 
 mod attributes;
@@ -134,6 +135,8 @@ pub struct Client {
     /// The HTTP client.
     pub(crate) client: Box<dyn HttpClient>,
 }
+
+assert_impl_all!(Client: Send, Sync);
 
 impl Client {
     /// Creates a builder to initialize a [`Client`] instance.
@@ -2111,6 +2114,8 @@ pub struct EventBatch {
     pub(crate) to: String,
 }
 
+assert_impl_all!(EventBatch: Send, Sync);
+
 impl EventBatch {
     pub(crate) fn new(events: Vec<Event>, from: String, to: String) -> Self {
         Self { events, from, to }
@@ -2255,6 +2260,8 @@ pub struct Nodes {
     /// The ID of the public link these nodes are from.
     pub(crate) download_id: Option<String>,
 }
+
+assert_impl_all!(Nodes: Send, Sync);
 
 impl Nodes {
     pub(crate) fn new(


### PR DESCRIPTION
This PR changes the definition of the `HttpClient` trait to allow `Client` to implement both `Send` and `Sync`.  
This prevented anyone from spawning tasks referencing `Client` on runtimes that require `Send` futures, like the `tokio` multi-threaded runtime.  
