### PR TITLE
Changed `timeout` setter to take an `Option`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,8 @@ impl ClientBuilder {
     }
 
     /// Sets the timeout duration to use for each request.
-    pub fn timeout(mut self, duration: Duration) -> Self {
-        self.timeout = Some(duration);
+    pub fn timeout(mut self, duration: Option<Duration>) -> Self {
+        self.timeout = duration;
         self
     }
 


### PR DESCRIPTION
This PR changes `timeout` to accept an `Option<Duration>` rather than just a `Duration`.  
This makes it possible to disable the timeout mechanism, allowing requests to wait an unbounded amount of time.
