### PR TITLE
Support for password-protected shared links

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
         env:
           MEGA_EMAIL: ${{ secrets.MEGA_EMAIL }}
           MEGA_PASSWORD: ${{ secrets.MEGA_PASSWORD }}
-          MEGA_PUBLIC_URL: ${{ secrets.MEGA_PUBLIC_URL }}
           MEGA_SESSION: ${{ secrets.MEGA_SESSION }}
+          MEGA_PUBLIC_URL: ${{ secrets.MEGA_PUBLIC_URL }}
+          MEGA_PROTECTED_URL: ${{ secrets.MEGA_PROTECTED_URL }}
+          MEGA_PROTECTED_PASSWORD: ${{ secrets.MEGA_PROTECTED_PASSWORD }}
         run: cargo test --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `Client::resume_session` method.
 - Added `Client::serialize_session` method.
+- Added `Client::fetch_protected_nodes` method.
 
 ### Changed
 
 - Added `#[non_exhaustive]` attribute on `Error` enum.
 - Changed `Error` variants from tuples to named fields.
+- Changed `Client` to implement the `Send` and `Sync` traits.
+- Changed `ClientBuilder::timeout` method to take an `Option<Duration>` instead of just `Duration`.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
  "futures",
  "hex",
  "hkdf",
+ "hmac",
  "indicatif",
  "pbkdf2",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 description = "A client API library for interacting with MEGA"
 repository = "https://github.com/Hirevo/mega-rs"
 documentation = "https://docs.rs/mega"
-keywords = ["protocol", "api", "mega", "web"]
-categories = ["api-bindings"]
+keywords = ["mega", "api", "cloud", "storage"]
+categories = ["api-bindings", "web-programming", "web-programming::http-client"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ crc32fast = "1.3.2"
 reqwest = { version = "0.11.14", features = ["json", "stream"], optional = true }
 tokio = { version = "1.25.0", features = ["time"], optional = true }
 tokio-util = { version = "0.7.7", features = ["compat", "codec"], optional = true }
+hmac = "0.12.1"
 static_assertions = "1.1.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ Features
 - [x] Retries (exponential-backoff) support
 - [x] Downloading thumbnails and preview images
 - [x] Uploading thumbnails and preview images
-- [x] Support for public shared links
-- [ ] Support for password-protected shared links
-- [ ] Create public shared links to owned nodes
-- [ ] Uploading to shared private folders
+- [x] Listing and downloading from public shared links
+- [x] Listing and downloading from password-protected shared links
+- [ ] Creating public shared links to owned nodes
+- [ ] Creating password-protected shared links to owned nodes
+- [ ] Support for privately-shared nodes (shares between MEGA contacts)
 - [x] Server-to-Client events support
 
 Examples

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 About
 -----
 
-This is an API client library for interacting with MEGA's API using Rust.  
+This is an (unofficial) API client library for interacting with MEGA's API using Rust.  
 
 This library aims to implement most (if not all) interactions with MEGA's API in pure Rust.  
 
@@ -37,6 +37,12 @@ It can also allow for more fine-grained control over how the operations are carr
 
 Features
 --------
+
+> All features marked as not yet implemented are ideas of things that could be done, and not necessarily an indication of it currently being worked on.
+
+> These are also non-exhaustive, so if there is a feature that you'd like to see done, feel free to open an issue to show your interest in it, regardless of whether it is mentionned in this list or not.
+
+> If you wish to contribute to this project, feel free to use this list to see if there is something you would be interested to either work on, or simply sharing some of your knowledge on how it could be achieved.
 
 - [x] Login with MEGA
   - [x] MFA support
@@ -57,7 +63,7 @@ Features
 - [x] Listing and downloading from password-protected shared links
 - [ ] Creating public shared links to owned nodes
 - [ ] Creating password-protected shared links to owned nodes
-- [ ] Support for privately-shared nodes (shares between MEGA contacts)
+- [ ] Support for privately-shared nodes (direct shares between MEGA contacts)
 - [x] Server-to-Client events support
 
 Examples

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,15 @@ pub enum Error {
     /// Missing user session.
     #[error("missing user session (consider logging in first)")]
     MissingUserSession,
+    /// Invalid URL format.
+    #[error("invalid URL format")]
+    InvalidUrlFormat,
+    /// The URL too short.
+    #[error("the URL too short")]
+    UrlTooShort,
+    /// Invalid algorithm version.
+    #[error("invalid algorithm version")]
+    InvalidAlgorithmVersion { version: u8 },
     /// Invalid session kind.
     #[error("invalid session kind")]
     InvalidSessionKind,
@@ -109,6 +118,13 @@ pub enum Error {
         /// The source `hkdf` invalid PRK length error.
         #[from]
         source: hkdf::InvalidPrkLength,
+    },
+    /// HMAC verification error.
+    #[error("HMAC mismatch (invalid link or wrong password)")]
+    HmacMismatch {
+        /// The source `hmac` verification error.
+        #[from]
+        source: hmac::digest::MacError,
     },
     /// AES-GCM error.
     #[error("AES-GCM error: {source}")]

--- a/tests/protected_file_fetch.rs
+++ b/tests/protected_file_fetch.rs
@@ -1,0 +1,21 @@
+//!
+//! Integration test for fetching nodes from password-protected MEGA URLs.
+//!
+
+use std::env;
+
+#[tokio::test]
+async fn protected_url_fetch_test() {
+    let protected_url =
+        env::var("MEGA_PROTECTED_URL").expect("missing MEGA_PROTECTED_URL environment variable");
+    let password = env::var("MEGA_PROTECTED_PASSWORD")
+        .expect("missing MEGA_PROTECTED_PASSWORD environment variable");
+
+    let http_client = reqwest::Client::new();
+    let mega = mega::Client::builder().build(http_client).unwrap();
+
+    let _nodes = mega
+        .fetch_protected_nodes(&protected_url, &password)
+        .await
+        .expect("could not fetch nodes from protected URL");
+}


### PR DESCRIPTION
This PR adds support for listing and downloading nodes from password-protected shared links.  

The is done using a new `fetch_protected_nodes` method on `Client`, which accepts both the MEGA password-protected link and the password itself.  

The format for these links is `https://mega.nz/#P!{payload}` (where `{payload}` is a base64url-encoded string).  

We implement both verification algorithm version `1` and `2` (basically the only ones currently in existence, I think).  

From a user perspective, the nodes obtained from this method can be used in the exact same way as those from the `fetch_public_nodes` method.  

Like `fetch_public_nodes`, it does not require a user session to be established in order to fetch nodes this way.  

We also make minor changes to how shared links are parsed, including in `fetch_public_nodes`.  