### PR TITLE
Added session management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Client::has_user_session` method.
+- Added `Client::list_sessions` method.
+- Added `Client::kill_sessions` method.
+- Added `Client::kill_all_sessions` method.
+- Added `Client::get_current_user_info` method.
+- Added `SessionInfo` struct.
+- Added `UserInfo` struct.
+
 ### Changed
 
 ### Fixed

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,10 @@ pub enum Error {
     UrlTooShort,
     /// Invalid algorithm version.
     #[error("invalid algorithm version")]
-    InvalidAlgorithmVersion { version: u8 },
+    InvalidAlgorithmVersion {
+        /// The encountered algorithm version.
+        version: u8,
+    },
     /// Invalid session kind.
     #[error("invalid session kind")]
     InvalidSessionKind,
@@ -62,6 +65,20 @@ pub enum Error {
     /// The involved event cursors do not match, continuing would result in inconsistencies.
     #[error("the involved event cursors do not match, continuing would result in inconsistencies")]
     EventCursorMismatch,
+    /// UTF-8 validation error.
+    #[error("UTF-8 validation error: {source}")]
+    FromUtf8Error {
+        /// The source error.
+        #[from]
+        source: std::string::FromUtf8Error,
+    },
+    /// Integer parsing error.
+    #[error("integer parse error: {source}")]
+    ParseIntError {
+        /// The source error.
+        #[from]
+        source: std::num::ParseIntError,
+    },
     /// Reqwest error.
     #[cfg(feature = "reqwest")]
     #[error("`reqwest` error: {source}")]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,0 +1,54 @@
+use chrono::{DateTime, TimeZone, Utc};
+
+use crate::protocol::commands;
+
+/// Represents information about a user session.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionInfo {
+    /// The ID of the session.
+    pub id: String,
+    /// The creation date of the session.
+    pub created_at: DateTime<Utc>,
+    /// The date of last activity of the session.
+    pub last_activity_at: DateTime<Utc>,
+    /// The user agent string for the session.
+    pub user_agent: String,
+    /// The IP address of the session.
+    pub ip: String,
+    /// The country code for the session.
+    pub country_code: String,
+    /// Whether this session is the current one.
+    pub current: bool,
+    /// Whether this session is still alive.
+    pub alive: bool,
+}
+
+impl From<commands::SessionInfo> for SessionInfo {
+    fn from(value: commands::SessionInfo) -> Self {
+        Self {
+            id: value.id,
+            created_at: Utc.timestamp_opt(value.timestamp, 0).unwrap(),
+            last_activity_at: Utc.timestamp_opt(value.mru, 0).unwrap(),
+            user_agent: value.user_agent,
+            ip: value.ip,
+            country_code: value.country,
+            current: value.current == 1,
+            alive: value.alive == 1,
+        }
+    }
+}
+
+impl From<&commands::SessionInfo> for SessionInfo {
+    fn from(value: &commands::SessionInfo) -> Self {
+        Self {
+            id: value.id.clone(),
+            created_at: Utc.timestamp_opt(value.timestamp, 0).unwrap(),
+            last_activity_at: Utc.timestamp_opt(value.mru, 0).unwrap(),
+            user_agent: value.user_agent.clone(),
+            ip: value.ip.clone(),
+            country_code: value.country.clone(),
+            current: value.current == 1,
+            alive: value.alive == 1,
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for listing the MEGA sessions of the current user, as well as support for killing some (or all) of these sessions.  

We also add two other methods:
- `Client::has_user_session`, to quickly determine if the current client currently has a user session going.  
- `Client::get_current_user_info`, to get information about the current user.  
