### PR TITLE
Fixed panic with invalid RSA private keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed panic due to unexpected RSA private key format (eg. during login ceremony).
+
 ### Removed
 
 [0.7.2] - 2024-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Error::InvalidRsaPrivateKeyFormat` variant.
+
 ### Changed
 
 ### Fixed

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,9 @@ pub enum Error {
         /// The encountered login version.
         version: i32,
     },
+    /// Invalid RSA private key format.
+    #[error("invalid RSA private key format")]
+    InvalidRsaPrivateKeyFormat,
     /// Failed condensed MAC verification.
     #[error("condensed MAC mismatch")]
     CondensedMacMismatch,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,12 +263,12 @@ impl Client {
         let privk = {
             let mut privk = BASE64_URL_SAFE_NO_PAD.decode(&response.privk)?;
             utils::decrypt_ebc_in_place(&key, &mut privk);
-            let (p, q, d, u) = utils::rsa::get_rsa_key(&privk);
+            let (p, q, d, u) = utils::rsa::get_rsa_key(&privk)?;
             RsaPrivateKey { p, q, d, u }
         };
 
         let sid = {
-            let (m, _) = utils::rsa::get_mpi(&csid);
+            let (m, _) = utils::rsa::get_mpi(&csid)?;
             let sid = utils::rsa::decrypt_rsa(&m, &privk.p, &privk.q, &privk.d);
             BASE64_URL_SAFE_NO_PAD.encode(&sid.to_bytes_be()[..43])
         };
@@ -341,7 +341,7 @@ impl Client {
         let privk = {
             let mut privk = BASE64_URL_SAFE_NO_PAD.decode(&response.privk)?;
             utils::decrypt_ebc_in_place(&key, &mut privk);
-            let (p, q, d, u) = utils::rsa::get_rsa_key(&privk);
+            let (p, q, d, u) = utils::rsa::get_rsa_key(&privk)?;
             RsaPrivateKey { p, q, d, u }
         };
 

--- a/src/utils/rsa.rs
+++ b/src/utils/rsa.rs
@@ -30,7 +30,9 @@ pub(crate) fn get_mpi(data: &[u8]) -> Result<(rsa::BigUint, &[u8])> {
     Ok((rsa::BigUint::from_bytes_be(head), tail))
 }
 
-pub(crate) fn get_rsa_key(data: &[u8]) -> Result<(rsa::BigUint, rsa::BigUint, rsa::BigUint, rsa::BigUint)> {
+pub(crate) fn get_rsa_key(
+    data: &[u8],
+) -> Result<(rsa::BigUint, rsa::BigUint, rsa::BigUint, rsa::BigUint)> {
     let (p, data) = get_mpi(data)?;
     let (q, data) = get_mpi(data)?;
     let (d, data) = get_mpi(data)?;


### PR DESCRIPTION
Previously, whenever we encountered an RSA private key that was unable to be decoded (which can happen during the login ceremony), the library would panic.

This is undesirable, we should instead communicate this issue to the user in a more graceful fashion, using a proper error variant, so that users of the library can react accordingly if they wish so. 

This PR does precisely this: it transforms what was previously a panic into a new proper error `Error::InvalidRsaPrivateKeyFormat` variant.

**Closes #18.**