### PR TITLE
Fix MEGA ug/usl response compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,31 @@ impl Client {
         self.state.session.is_some()
     }
 
+    fn decode_optional_base64_string(value: Option<&str>) -> Result<Option<String>> {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        let decoded = BASE64_URL_SAFE_NO_PAD.decode(value)?;
+        if decoded.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(String::from_utf8(decoded)?))
+    }
+
+    fn decode_optional_base64_u32(value: Option<&str>) -> Result<Option<u32>> {
+        let Some(value) = Self::decode_optional_base64_string(value)? else {
+            return Ok(None);
+        };
+        Ok(Some(value.parse::<u32>()?))
+    }
+
+    fn decode_optional_base64_i32(value: Option<&str>) -> Result<Option<i32>> {
+        let Some(value) = Self::decode_optional_base64_string(value)? else {
+            return Ok(None);
+        };
+        Ok(Some(value.parse::<i32>()?))
+    }
+
     /// Get information about the current user.
     pub async fn get_current_user_info(&self) -> Result<UserInfo> {
         let request = Request::UserInfo { v: None };
@@ -422,36 +447,19 @@ impl Client {
                 String::from_utf8(decoded)?
             },
             email: response.email.clone(),
-            country_code: 'result: {
-                let Some(country) = &response.country else {
-                    break 'result None;
-                };
-                let decoded = BASE64_URL_SAFE_NO_PAD.decode(&country)?;
-                let country = String::from_utf8(decoded)?;
-                Some(country)
-            },
+            country_code: Self::decode_optional_base64_string(response.country.as_deref())?,
             birth_date: 'result: {
-                let Some(day) = &response.birthday else {
+                let Some(day) = Self::decode_optional_base64_u32(response.birthday.as_deref())?
+                else {
                     break 'result None;
                 };
-                let Some(month) = &response.birthmonth else {
+                let Some(month) = Self::decode_optional_base64_u32(response.birthmonth.as_deref())?
+                else {
                     break 'result None;
                 };
-                let Some(year) = &response.birthyear else {
+                let Some(year) = Self::decode_optional_base64_i32(response.birthyear.as_deref())?
+                else {
                     break 'result None;
-                };
-
-                let day: u32 = {
-                    let decoded = BASE64_URL_SAFE_NO_PAD.decode(&day)?;
-                    String::from_utf8(decoded)?.parse::<u32>()?
-                };
-                let month: u32 = {
-                    let decoded = BASE64_URL_SAFE_NO_PAD.decode(&month)?;
-                    String::from_utf8(decoded)?.parse::<u32>()?
-                };
-                let year: i32 = {
-                    let decoded = BASE64_URL_SAFE_NO_PAD.decode(&year)?;
-                    String::from_utf8(decoded)?.parse::<i32>()?
                 };
 
                 NaiveDate::from_ymd_opt(year, month, day)
@@ -2777,4 +2785,33 @@ pub struct UserInfo {
     pub birth_date: Option<NaiveDate>,
     /// The country code of the user.
     pub country_code: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn optional_base64_fields_treat_empty_payload_as_missing() {
+        assert_eq!(
+            Client::decode_optional_base64_string(Some("")).unwrap(),
+            None
+        );
+        assert_eq!(
+            Client::decode_optional_base64_string(Some(&BASE64_URL_SAFE_NO_PAD.encode("US")))
+                .unwrap(),
+            Some(String::from("US"))
+        );
+        assert_eq!(Client::decode_optional_base64_u32(Some("")).unwrap(), None);
+        assert_eq!(
+            Client::decode_optional_base64_u32(Some(&BASE64_URL_SAFE_NO_PAD.encode("12"))).unwrap(),
+            Some(12)
+        );
+        assert_eq!(Client::decode_optional_base64_i32(Some("")).unwrap(), None);
+        assert_eq!(
+            Client::decode_optional_base64_i32(Some(&BASE64_URL_SAFE_NO_PAD.encode("2024")))
+                .unwrap(),
+            Some(2024)
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use aes::Aes128;
 use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
-use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use cipher::generic_array::GenericArray;
 use cipher::{BlockDecryptMut, BlockEncrypt, BlockEncryptMut, KeyInit, KeyIvInit, StreamCipher};
 use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -23,12 +23,14 @@ mod fingerprint;
 mod http;
 mod protocol;
 mod sessions;
+mod user_info;
 mod utils;
 
 pub use crate::error::{Error, ErrorCode, Result};
 pub use crate::fingerprint::{compute_condensed_mac, compute_sparse_checksum};
 pub use crate::protocol::commands::{FileNode, NodeKind};
 pub use crate::sessions::SessionInfo;
+pub use crate::user_info::UserInfo;
 pub use crate::utils::StorageQuotas;
 
 use crate::attributes::NodeAttributes;
@@ -396,31 +398,6 @@ impl Client {
         self.state.session.is_some()
     }
 
-    fn decode_optional_base64_string(value: Option<&str>) -> Result<Option<String>> {
-        let Some(value) = value else {
-            return Ok(None);
-        };
-        let decoded = BASE64_URL_SAFE_NO_PAD.decode(value)?;
-        if decoded.is_empty() {
-            return Ok(None);
-        }
-        Ok(Some(String::from_utf8(decoded)?))
-    }
-
-    fn decode_optional_base64_u32(value: Option<&str>) -> Result<Option<u32>> {
-        let Some(value) = Self::decode_optional_base64_string(value)? else {
-            return Ok(None);
-        };
-        Ok(Some(value.parse::<u32>()?))
-    }
-
-    fn decode_optional_base64_i32(value: Option<&str>) -> Result<Option<i32>> {
-        let Some(value) = Self::decode_optional_base64_string(value)? else {
-            return Ok(None);
-        };
-        Ok(Some(value.parse::<i32>()?))
-    }
-
     /// Get information about the current user.
     pub async fn get_current_user_info(&self) -> Result<UserInfo> {
         let request = Request::UserInfo { v: None };
@@ -436,35 +413,7 @@ impl Client {
             }
         };
 
-        Ok(UserInfo {
-            id: response.u.clone(),
-            first_name: {
-                let decoded = BASE64_URL_SAFE_NO_PAD.decode(&response.firstname)?;
-                String::from_utf8(decoded)?
-            },
-            last_name: {
-                let decoded = BASE64_URL_SAFE_NO_PAD.decode(&response.lastname)?;
-                String::from_utf8(decoded)?
-            },
-            email: response.email.clone(),
-            country_code: Self::decode_optional_base64_string(response.country.as_deref())?,
-            birth_date: 'result: {
-                let Some(day) = Self::decode_optional_base64_u32(response.birthday.as_deref())?
-                else {
-                    break 'result None;
-                };
-                let Some(month) = Self::decode_optional_base64_u32(response.birthmonth.as_deref())?
-                else {
-                    break 'result None;
-                };
-                let Some(year) = Self::decode_optional_base64_i32(response.birthyear.as_deref())?
-                else {
-                    break 'result None;
-                };
-
-                NaiveDate::from_ymd_opt(year, month, day)
-            },
-        })
+        UserInfo::try_from(response)
     }
 
     /// Lists the user's MEGA sessions.
@@ -2767,51 +2716,5 @@ impl LastModified {
             LastModified::Now => Utc::now(),
             LastModified::Set(datetime) => datetime,
         }
-    }
-}
-
-/// Represents information about a MEGA user.
-#[derive(Debug, Clone, PartialEq)]
-pub struct UserInfo {
-    /// The ID of the user.
-    pub id: String,
-    /// The first name of the user.
-    pub first_name: String,
-    /// The last name of the user.
-    pub last_name: String,
-    /// The main email of the user.
-    pub email: String,
-    /// The birth date of the user.
-    pub birth_date: Option<NaiveDate>,
-    /// The country code of the user.
-    pub country_code: Option<String>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn optional_base64_fields_treat_empty_payload_as_missing() {
-        assert_eq!(
-            Client::decode_optional_base64_string(Some("")).unwrap(),
-            None
-        );
-        assert_eq!(
-            Client::decode_optional_base64_string(Some(&BASE64_URL_SAFE_NO_PAD.encode("US")))
-                .unwrap(),
-            Some(String::from("US"))
-        );
-        assert_eq!(Client::decode_optional_base64_u32(Some("")).unwrap(), None);
-        assert_eq!(
-            Client::decode_optional_base64_u32(Some(&BASE64_URL_SAFE_NO_PAD.encode("12"))).unwrap(),
-            Some(12)
-        );
-        assert_eq!(Client::decode_optional_base64_i32(Some("")).unwrap(), None);
-        assert_eq!(
-            Client::decode_optional_base64_i32(Some(&BASE64_URL_SAFE_NO_PAD.encode("2024")))
-                .unwrap(),
-            Some(2024)
-        );
     }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -879,6 +879,78 @@ mod tests {
     use super::*;
     use json::json;
 
+    // These regressions mirror the MEGA SDK's ug parser and attribute handling:
+    // - https://github.com/meganz/sdk/blob/d41138b3b6acce78353434af30e582d38bba6a73/src/commands.cpp#L4393-L4404
+    // - https://github.com/meganz/sdk/blob/d41138b3b6acce78353434af30e582d38bba6a73/src/commands.cpp#L4584-L4597
+    // - https://github.com/meganz/sdk/blob/d41138b3b6acce78353434af30e582d38bba6a73/src/commands.cpp#L5576-L5585
+    //
+    // These regressions mirror the MEGA SDK's usl parser, which reads session rows as
+    // positional arrays and tolerates missing textual values while still consuming the
+    // extra id/alive/device-id fields:
+    // - https://github.com/meganz/sdk/blob/d41138b3b6acce78353434af30e582d38bba6a73/src/commands.cpp#L6503-L6521
+
+    #[test]
+    fn user_info_response_defaults_missing_name_fields() {
+        let request = Request::UserInfo { v: None };
+        let value = json!({
+            "u": "user-handle",
+            "s": 0,
+            "email": "user@example.com",
+            "country": null,
+            "birthday": null,
+            "birthmonth": null,
+            "birthyear": null,
+            "name": "",
+            "k": "",
+            "c": 0,
+            "pubk": "",
+            "privk": "",
+            "terms": null,
+            "ts": "0"
+        });
+
+        let Response::UserInfo(response) = request.parse_response_data(value).unwrap() else {
+            panic!("expected user info response");
+        };
+
+        assert_eq!(response.firstname, "");
+        assert_eq!(response.lastname, "");
+        assert_eq!(response.country, None);
+        assert_eq!(response.birthday, None);
+    }
+
+    #[test]
+    fn user_info_response_preserves_optional_attr_payloads() {
+        let request = Request::UserInfo { v: None };
+        let value = json!({
+            "u": "user-handle",
+            "s": 0,
+            "email": "user@example.com",
+            "firstname": "SmFuZQ",
+            "lastname": "RG9l",
+            "country": "",
+            "birthday": "",
+            "birthmonth": "NQ",
+            "birthyear": "MjAyNg",
+            "name": "",
+            "k": "",
+            "c": 0,
+            "pubk": "",
+            "privk": "",
+            "terms": null,
+            "ts": "0"
+        });
+
+        let Response::UserInfo(response) = request.parse_response_data(value).unwrap() else {
+            panic!("expected user info response");
+        };
+
+        assert_eq!(response.country.as_deref(), Some(""));
+        assert_eq!(response.birthday.as_deref(), Some(""));
+        assert_eq!(response.birthmonth.as_deref(), Some("NQ"));
+        assert_eq!(response.birthyear.as_deref(), Some("MjAyNg"));
+    }
+
     #[test]
     fn list_sessions_response_accepts_megas_sequence_shape() {
         let request = Request::ListSessions { x: Some(1) };
@@ -927,5 +999,108 @@ mod tests {
         assert_eq!(response.sessions[0].country, "");
         assert_eq!(response.sessions[0].id, "abcdef01");
         assert_eq!(response.sessions[0].alive, 0);
+    }
+
+    #[test]
+    fn list_sessions_response_accepts_sequence_without_extended_fields() {
+        let request = Request::ListSessions { x: None };
+        let value = json!([[1716920000, 1716921111, "Firefox", "203.0.113.4", "US", 1]]);
+
+        let Response::ListSessions(response) = request.parse_response_data(value).unwrap() else {
+            panic!("expected list sessions response");
+        };
+
+        assert_eq!(response.sessions.len(), 1);
+        assert_eq!(response.sessions[0].id, "");
+        assert_eq!(response.sessions[0].alive, 0);
+        assert_eq!(response.sessions[0].current, 1);
+    }
+
+    #[test]
+    fn list_sessions_response_accepts_sequence_with_device_id_tail() {
+        let request = Request::ListSessions { x: Some(1) };
+        let value = json!([[
+            1716920000,
+            1716921111,
+            "Firefox",
+            "203.0.113.4",
+            "US",
+            1,
+            "abcdef01",
+            1,
+            "phone"
+        ]]);
+
+        let Response::ListSessions(response) = request.parse_response_data(value).unwrap() else {
+            panic!("expected list sessions response");
+        };
+
+        assert_eq!(response.sessions.len(), 1);
+        assert_eq!(response.sessions[0].id, "abcdef01");
+        assert_eq!(response.sessions[0].alive, 1);
+    }
+
+    #[test]
+    fn list_sessions_response_accepts_object_shape_fallback() {
+        let request = Request::ListSessions { x: Some(1) };
+        let value = json!([{
+            "timestamp": 1716920000,
+            "mru": 1716921111,
+            "user_agent": "Firefox",
+            "ip": "203.0.113.4",
+            "country": "US",
+            "current": 1,
+            "id": "abcdef01",
+            "alive": 1
+        }]);
+
+        let Response::ListSessions(response) = request.parse_response_data(value).unwrap() else {
+            panic!("expected list sessions response");
+        };
+
+        assert_eq!(response.sessions.len(), 1);
+        assert_eq!(response.sessions[0].user_agent, "Firefox");
+        assert_eq!(response.sessions[0].id, "abcdef01");
+        assert_eq!(response.sessions[0].alive, 1);
+    }
+
+    #[test]
+    fn list_sessions_response_rejects_invalid_sequence_lengths() {
+        let request = Request::ListSessions { x: Some(1) };
+
+        assert!(request
+            .parse_response_data(json!([[
+                1716920000,
+                1716921111,
+                "Firefox",
+                "203.0.113.4",
+                "US"
+            ]]))
+            .is_err());
+        assert!(request
+            .parse_response_data(json!([[
+                1716920000,
+                1716921111,
+                "Firefox",
+                "203.0.113.4",
+                "US",
+                1,
+                "abcdef01"
+            ]]))
+            .is_err());
+        assert!(request
+            .parse_response_data(json!([[
+                1716920000,
+                1716921111,
+                "Firefox",
+                "203.0.113.4",
+                "US",
+                1,
+                "abcdef01",
+                1,
+                "phone",
+                "extra"
+            ]]))
+            .is_err());
     }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -406,7 +406,7 @@ pub struct ListSessionsResponse {
 }
 
 /// Represents information about a user session.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SessionInfo {
     #[serde(rename = "timestamp")]
     pub timestamp: i64,
@@ -424,6 +424,150 @@ pub struct SessionInfo {
     pub id: String,
     #[serde(rename = "alive")]
     pub alive: i32,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionInfoObject {
+    #[serde(rename = "timestamp")]
+    timestamp: i64,
+    #[serde(rename = "mru")]
+    mru: i64,
+    #[serde(rename = "user_agent")]
+    user_agent: String,
+    #[serde(rename = "ip")]
+    ip: String,
+    #[serde(rename = "country")]
+    country: String,
+    #[serde(rename = "current")]
+    current: i32,
+    #[serde(rename = "id")]
+    id: String,
+    #[serde(rename = "alive")]
+    alive: i32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum SessionInfoRepr {
+    Object(SessionInfoObject),
+    Sequence9(
+        (
+            i64,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            i32,
+            String,
+            i32,
+            Option<String>,
+        ),
+    ),
+    Sequence8(
+        (
+            i64,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            i32,
+            String,
+            i32,
+        ),
+    ),
+    Sequence6(
+        (
+            i64,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            i32,
+        ),
+    ),
+}
+
+impl From<SessionInfoObject> for SessionInfo {
+    fn from(value: SessionInfoObject) -> Self {
+        Self {
+            timestamp: value.timestamp,
+            mru: value.mru,
+            user_agent: value.user_agent,
+            ip: value.ip,
+            country: value.country,
+            current: value.current,
+            id: value.id,
+            alive: value.alive,
+        }
+    }
+}
+
+impl From<SessionInfoRepr> for SessionInfo {
+    fn from(value: SessionInfoRepr) -> Self {
+        match value {
+            SessionInfoRepr::Object(value) => value.into(),
+            SessionInfoRepr::Sequence9((
+                timestamp,
+                mru,
+                user_agent,
+                ip,
+                country,
+                current,
+                id,
+                alive,
+                _device_id,
+            )) => Self {
+                timestamp,
+                mru,
+                user_agent: user_agent.unwrap_or_default(),
+                ip: ip.unwrap_or_default(),
+                country: country.unwrap_or_default(),
+                current,
+                id,
+                alive,
+            },
+            SessionInfoRepr::Sequence8((
+                timestamp,
+                mru,
+                user_agent,
+                ip,
+                country,
+                current,
+                id,
+                alive,
+            )) => Self {
+                timestamp,
+                mru,
+                user_agent: user_agent.unwrap_or_default(),
+                ip: ip.unwrap_or_default(),
+                country: country.unwrap_or_default(),
+                current,
+                id,
+                alive,
+            },
+            SessionInfoRepr::Sequence6((timestamp, mru, user_agent, ip, country, current)) => {
+                Self {
+                    timestamp,
+                    mru,
+                    user_agent: user_agent.unwrap_or_default(),
+                    ip: ip.unwrap_or_default(),
+                    country: country.unwrap_or_default(),
+                    current,
+                    id: String::default(),
+                    alive: 0,
+                }
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SessionInfo {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(SessionInfoRepr::deserialize(deserializer)?.into())
+    }
 }
 
 /// Response for the `Request::KillSessions` message.
@@ -728,4 +872,60 @@ where
         seq.serialize_element(item.expose_secret())?;
     }
     seq.end()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use json::json;
+
+    #[test]
+    fn list_sessions_response_accepts_megas_sequence_shape() {
+        let request = Request::ListSessions { x: Some(1) };
+        let value = json!([[
+            1716920000,
+            1716921111,
+            "Firefox",
+            "203.0.113.4",
+            "US",
+            1,
+            "abcdef01",
+            1
+        ]]);
+
+        let Response::ListSessions(response) = request.parse_response_data(value).unwrap() else {
+            panic!("expected list sessions response");
+        };
+
+        assert_eq!(
+            response.sessions,
+            vec![SessionInfo {
+                timestamp: 1716920000,
+                mru: 1716921111,
+                user_agent: String::from("Firefox"),
+                ip: String::from("203.0.113.4"),
+                country: String::from("US"),
+                current: 1,
+                id: String::from("abcdef01"),
+                alive: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn list_sessions_response_treats_null_text_fields_as_empty() {
+        let request = Request::ListSessions { x: Some(1) };
+        let value = json!([[1716920000, 1716921111, null, null, null, 0, "abcdef01", 0, "phone"]]);
+
+        let Response::ListSessions(response) = request.parse_response_data(value).unwrap() else {
+            panic!("expected list sessions response");
+        };
+
+        assert_eq!(response.sessions.len(), 1);
+        assert_eq!(response.sessions[0].user_agent, "");
+        assert_eq!(response.sessions[0].ip, "");
+        assert_eq!(response.sessions[0].country, "");
+        assert_eq!(response.sessions[0].id, "abcdef01");
+        assert_eq!(response.sessions[0].alive, 0);
+    }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -433,11 +433,11 @@ struct SessionInfoObject {
     #[serde(rename = "mru")]
     mru: i64,
     #[serde(rename = "user_agent")]
-    user_agent: String,
+    user_agent: Option<String>,
     #[serde(rename = "ip")]
-    ip: String,
+    ip: Option<String>,
     #[serde(rename = "country")]
-    country: String,
+    country: Option<String>,
     #[serde(rename = "current")]
     current: i32,
     #[serde(rename = "id")]
@@ -492,9 +492,9 @@ impl From<SessionInfoObject> for SessionInfo {
         Self {
             timestamp: value.timestamp,
             mru: value.mru,
-            user_agent: value.user_agent,
-            ip: value.ip,
-            country: value.country,
+            user_agent: value.user_agent.unwrap_or_default(),
+            ip: value.ip.unwrap_or_default(),
+            country: value.country.unwrap_or_default(),
             current: value.current,
             id: value.id,
             alive: value.alive,
@@ -1062,6 +1062,44 @@ mod tests {
         assert_eq!(response.sessions[0].user_agent, "Firefox");
         assert_eq!(response.sessions[0].id, "abcdef01");
         assert_eq!(response.sessions[0].alive, 1);
+    }
+
+    #[test]
+    fn list_sessions_object_shape_treats_null_or_missing_text_fields_as_empty() {
+        let request = Request::ListSessions { x: Some(1) };
+        let value = json!([
+            {
+                "timestamp": 1716920000,
+                "mru": 1716921111,
+                "user_agent": null,
+                "ip": null,
+                "country": null,
+                "current": 1,
+                "id": "abcdef01",
+                "alive": 1
+            },
+            {
+                "timestamp": 1716920000,
+                "mru": 1716921111,
+                "current": 0,
+                "id": "abcdef02",
+                "alive": 0
+            }
+        ]);
+
+        let Response::ListSessions(response) = request.parse_response_data(value).unwrap() else {
+            panic!("expected list sessions response");
+        };
+
+        assert_eq!(response.sessions.len(), 2);
+        assert_eq!(response.sessions[0].user_agent, "");
+        assert_eq!(response.sessions[0].ip, "");
+        assert_eq!(response.sessions[0].country, "");
+        assert_eq!(response.sessions[1].user_agent, "");
+        assert_eq!(response.sessions[1].ip, "");
+        assert_eq!(response.sessions[1].country, "");
+        assert_eq!(response.sessions[1].id, "abcdef02");
+        assert_eq!(response.sessions[1].alive, 0);
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -70,10 +70,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn owned_protocol_session_maps_to_public_session_info() {
-        let session = SessionInfo::from(sample_protocol_session());
-
+    fn assert_session_mapped(session: &SessionInfo) {
         assert_eq!(session.id, "abcdef01");
         assert_eq!(
             session.created_at,
@@ -91,23 +88,17 @@ mod tests {
     }
 
     #[test]
+    fn owned_protocol_session_maps_to_public_session_info() {
+        let session = SessionInfo::from(sample_protocol_session());
+
+        assert_session_mapped(&session);
+    }
+
+    #[test]
     fn borrowed_protocol_session_maps_to_public_session_info() {
         let protocol = sample_protocol_session();
         let session = SessionInfo::from(&protocol);
 
-        assert_eq!(session.id, "abcdef01");
-        assert_eq!(
-            session.created_at,
-            Utc.timestamp_opt(1_716_920_000, 0).unwrap()
-        );
-        assert_eq!(
-            session.last_activity_at,
-            Utc.timestamp_opt(1_716_921_111, 0).unwrap()
-        );
-        assert_eq!(session.user_agent, "Firefox");
-        assert_eq!(session.ip, "203.0.113.4");
-        assert_eq!(session.country_code, "US");
-        assert!(session.current);
-        assert!(session.alive);
+        assert_session_mapped(&session);
     }
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -52,3 +52,62 @@ impl From<&commands::SessionInfo> for SessionInfo {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_protocol_session() -> commands::SessionInfo {
+        commands::SessionInfo {
+            timestamp: 1_716_920_000,
+            mru: 1_716_921_111,
+            user_agent: String::from("Firefox"),
+            ip: String::from("203.0.113.4"),
+            country: String::from("US"),
+            current: 1,
+            id: String::from("abcdef01"),
+            alive: 1,
+        }
+    }
+
+    #[test]
+    fn owned_protocol_session_maps_to_public_session_info() {
+        let session = SessionInfo::from(sample_protocol_session());
+
+        assert_eq!(session.id, "abcdef01");
+        assert_eq!(
+            session.created_at,
+            Utc.timestamp_opt(1_716_920_000, 0).unwrap()
+        );
+        assert_eq!(
+            session.last_activity_at,
+            Utc.timestamp_opt(1_716_921_111, 0).unwrap()
+        );
+        assert_eq!(session.user_agent, "Firefox");
+        assert_eq!(session.ip, "203.0.113.4");
+        assert_eq!(session.country_code, "US");
+        assert!(session.current);
+        assert!(session.alive);
+    }
+
+    #[test]
+    fn borrowed_protocol_session_maps_to_public_session_info() {
+        let protocol = sample_protocol_session();
+        let session = SessionInfo::from(&protocol);
+
+        assert_eq!(session.id, "abcdef01");
+        assert_eq!(
+            session.created_at,
+            Utc.timestamp_opt(1_716_920_000, 0).unwrap()
+        );
+        assert_eq!(
+            session.last_activity_at,
+            Utc.timestamp_opt(1_716_921_111, 0).unwrap()
+        );
+        assert_eq!(session.user_agent, "Firefox");
+        assert_eq!(session.ip, "203.0.113.4");
+        assert_eq!(session.country_code, "US");
+        assert!(session.current);
+        assert!(session.alive);
+    }
+}

--- a/src/user_info.rs
+++ b/src/user_info.rs
@@ -1,0 +1,194 @@
+use chrono::NaiveDate;
+
+use crate::protocol::commands;
+use crate::Result;
+
+mod decoding;
+
+/// Represents information about a MEGA user.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UserInfo {
+    /// The ID of the user.
+    pub id: String,
+    /// The first name of the user.
+    pub first_name: String,
+    /// The last name of the user.
+    pub last_name: String,
+    /// The main email of the user.
+    pub email: String,
+    /// The birth date of the user.
+    pub birth_date: Option<NaiveDate>,
+    /// The country code of the user.
+    pub country_code: Option<String>,
+}
+
+impl TryFrom<&commands::UserInfoResponse> for UserInfo {
+    type Error = crate::Error;
+
+    fn try_from(value: &commands::UserInfoResponse) -> Result<Self> {
+        Ok(Self {
+            id: value.u.clone(),
+            first_name: decoding::decode_required_base64_string(&value.firstname)?,
+            last_name: decoding::decode_required_base64_string(&value.lastname)?,
+            email: value.email.clone(),
+            country_code: decoding::decode_optional_base64_string(value.country.as_deref())?,
+            birth_date: 'result: {
+                let Some(day) = decoding::decode_optional_base64_u32(value.birthday.as_deref())?
+                else {
+                    break 'result None;
+                };
+                let Some(month) =
+                    decoding::decode_optional_base64_u32(value.birthmonth.as_deref())?
+                else {
+                    break 'result None;
+                };
+                let Some(year) = decoding::decode_optional_base64_i32(value.birthyear.as_deref())?
+                else {
+                    break 'result None;
+                };
+
+                NaiveDate::from_ymd_opt(year, month, day)
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
+
+    use super::*;
+    use crate::protocol::commands::UserInfoResponse;
+
+    // These regressions mirror the MEGA SDK's ug parser and empty-attribute handling:
+    // - https://github.com/meganz/sdk/blob/d41138b3b6acce78353434af30e582d38bba6a73/src/commands.cpp#L4393-L4404
+    // - https://github.com/meganz/sdk/blob/d41138b3b6acce78353434af30e582d38bba6a73/src/commands.cpp#L4584-L4597
+    // - https://github.com/meganz/sdk/blob/d41138b3b6acce78353434af30e582d38bba6a73/src/commands.cpp#L5048-L5072
+    // - https://github.com/meganz/sdk/blob/d41138b3b6acce78353434af30e582d38bba6a73/src/commands.cpp#L5576-L5585
+
+    fn sample_user_info_response() -> UserInfoResponse {
+        UserInfoResponse {
+            u: String::from("user-handle"),
+            s: 0,
+            email: String::from("user@example.com"),
+            firstname: BASE64_URL_SAFE_NO_PAD.encode("Jane"),
+            lastname: BASE64_URL_SAFE_NO_PAD.encode("Doe"),
+            country: None,
+            birthday: None,
+            birthmonth: None,
+            birthyear: None,
+            name: String::new(),
+            key: String::new(),
+            c: 0,
+            pubk: String::new(),
+            privk: String::new(),
+            terms: None,
+            ts: String::from("0"),
+        }
+    }
+
+    #[test]
+    fn optional_base64_fields_treat_empty_payload_as_missing() {
+        assert_eq!(
+            decoding::decode_optional_base64_string(Some("")).unwrap(),
+            None
+        );
+        assert_eq!(
+            decoding::decode_optional_base64_string(Some(&BASE64_URL_SAFE_NO_PAD.encode("US")))
+                .unwrap(),
+            Some(String::from("US"))
+        );
+        assert_eq!(
+            decoding::decode_optional_base64_u32(Some("")).unwrap(),
+            None
+        );
+        assert_eq!(
+            decoding::decode_optional_base64_u32(Some(&BASE64_URL_SAFE_NO_PAD.encode("12")))
+                .unwrap(),
+            Some(12)
+        );
+        assert_eq!(
+            decoding::decode_optional_base64_i32(Some("")).unwrap(),
+            None
+        );
+        assert_eq!(
+            decoding::decode_optional_base64_i32(Some(&BASE64_URL_SAFE_NO_PAD.encode("2024")))
+                .unwrap(),
+            Some(2024)
+        );
+    }
+
+    #[test]
+    fn user_info_response_treats_empty_optional_attrs_as_missing() {
+        let response = UserInfoResponse {
+            country: Some(String::new()),
+            birthday: Some(String::new()),
+            birthmonth: Some(String::new()),
+            birthyear: Some(String::new()),
+            ..sample_user_info_response()
+        };
+
+        let user = UserInfo::try_from(&response).unwrap();
+
+        assert_eq!(user.id, "user-handle");
+        assert_eq!(user.first_name, "Jane");
+        assert_eq!(user.last_name, "Doe");
+        assert_eq!(user.email, "user@example.com");
+        assert_eq!(user.country_code, None);
+        assert_eq!(user.birth_date, None);
+    }
+
+    #[test]
+    fn user_info_response_maps_populated_optional_attrs() {
+        let response = UserInfoResponse {
+            country: Some(BASE64_URL_SAFE_NO_PAD.encode("US")),
+            birthday: Some(BASE64_URL_SAFE_NO_PAD.encode("27")),
+            birthmonth: Some(BASE64_URL_SAFE_NO_PAD.encode("5")),
+            birthyear: Some(BASE64_URL_SAFE_NO_PAD.encode("2026")),
+            ..sample_user_info_response()
+        };
+
+        let user = UserInfo::try_from(&response).unwrap();
+
+        assert_eq!(user.country_code, Some(String::from("US")));
+        assert_eq!(user.birth_date, NaiveDate::from_ymd_opt(2026, 5, 27));
+    }
+
+    #[test]
+    fn user_info_response_returns_none_for_partial_birth_date() {
+        for response in [
+            UserInfoResponse {
+                birthday: Some(BASE64_URL_SAFE_NO_PAD.encode("27")),
+                birthmonth: Some(BASE64_URL_SAFE_NO_PAD.encode("5")),
+                ..sample_user_info_response()
+            },
+            UserInfoResponse {
+                birthday: Some(BASE64_URL_SAFE_NO_PAD.encode("27")),
+                birthyear: Some(BASE64_URL_SAFE_NO_PAD.encode("2026")),
+                ..sample_user_info_response()
+            },
+            UserInfoResponse {
+                birthmonth: Some(BASE64_URL_SAFE_NO_PAD.encode("5")),
+                birthyear: Some(BASE64_URL_SAFE_NO_PAD.encode("2026")),
+                ..sample_user_info_response()
+            },
+        ] {
+            let user = UserInfo::try_from(&response).unwrap();
+            assert_eq!(user.birth_date, None);
+        }
+    }
+
+    #[test]
+    fn user_info_response_returns_none_for_invalid_birth_date() {
+        let response = UserInfoResponse {
+            birthday: Some(BASE64_URL_SAFE_NO_PAD.encode("31")),
+            birthmonth: Some(BASE64_URL_SAFE_NO_PAD.encode("2")),
+            birthyear: Some(BASE64_URL_SAFE_NO_PAD.encode("2026")),
+            ..sample_user_info_response()
+        };
+
+        let user = UserInfo::try_from(&response).unwrap();
+
+        assert_eq!(user.birth_date, None);
+    }
+}

--- a/src/user_info/decoding.rs
+++ b/src/user_info/decoding.rs
@@ -1,0 +1,33 @@
+use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
+
+use crate::Result;
+
+pub(super) fn decode_required_base64_string(value: &str) -> Result<String> {
+    let decoded = BASE64_URL_SAFE_NO_PAD.decode(value)?;
+    Ok(String::from_utf8(decoded)?)
+}
+
+pub(super) fn decode_optional_base64_string(value: Option<&str>) -> Result<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let decoded = BASE64_URL_SAFE_NO_PAD.decode(value)?;
+    if decoded.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(String::from_utf8(decoded)?))
+}
+
+pub(super) fn decode_optional_base64_u32(value: Option<&str>) -> Result<Option<u32>> {
+    let Some(value) = decode_optional_base64_string(value)? else {
+        return Ok(None);
+    };
+    Ok(Some(value.parse::<u32>()?))
+}
+
+pub(super) fn decode_optional_base64_i32(value: Option<&str>) -> Result<Option<i32>> {
+    let Some(value) = decode_optional_base64_string(value)? else {
+        return Ok(None);
+    };
+    Ok(Some(value.parse::<i32>()?))
+}

--- a/src/user_info/decoding.rs
+++ b/src/user_info/decoding.rs
@@ -1,6 +1,7 @@
 use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
+use std::str::FromStr;
 
-use crate::Result;
+use crate::{Error, Result};
 
 pub(super) fn decode_required_base64_string(value: &str) -> Result<String> {
     let decoded = BASE64_URL_SAFE_NO_PAD.decode(value)?;
@@ -18,16 +19,21 @@ pub(super) fn decode_optional_base64_string(value: Option<&str>) -> Result<Optio
     Ok(Some(String::from_utf8(decoded)?))
 }
 
-pub(super) fn decode_optional_base64_u32(value: Option<&str>) -> Result<Option<u32>> {
+fn decode_optional_base64_parsed<T>(value: Option<&str>) -> Result<Option<T>>
+where
+    T: FromStr,
+    Error: From<T::Err>,
+{
     let Some(value) = decode_optional_base64_string(value)? else {
         return Ok(None);
     };
-    Ok(Some(value.parse::<u32>()?))
+    Ok(Some(value.parse::<T>()?))
+}
+
+pub(super) fn decode_optional_base64_u32(value: Option<&str>) -> Result<Option<u32>> {
+    decode_optional_base64_parsed(value)
 }
 
 pub(super) fn decode_optional_base64_i32(value: Option<&str>) -> Result<Option<i32>> {
-    let Some(value) = decode_optional_base64_string(value)? else {
-        return Ok(None);
-    };
-    Ok(Some(value.parse::<i32>()?))
+    decode_optional_base64_parsed(value)
 }


### PR DESCRIPTION
## Summary

Fix two response compatibility issues against MEGA's current API / SDK behavior:

- `ug` / user info: accept empty optional user attributes instead of treating them as populated values
- `usl` / list sessions: accept MEGA's positional session-array response shape

## What changed

### `ug` / user info
- treat empty optional base64-encoded attributes as missing
- correctly handle empty `country`, `birthday`, `birthmonth`, and `birthyear`
- keep partial or invalid birth-date data from producing a bogus date
- move user-info response conversion into a dedicated typed conversion with small internal decoding helpers

### `usl` / list sessions
- deserialize MEGA's positional session rows
- tolerate null/empty textual fields the way the MEGA SDK does
- preserve object-shape fallback compatibility
- reduce parser overhead while keeping behavior the same

## Tests

Added SDK-linked regression coverage for:
- `ug` protocol parsing and public `UserInfo` mapping
- `usl` protocol parsing and public `SessionInfo` mapping
- empty optional attrs
- partial / invalid birth-date cases
- 6 / 8 / 9-field session row shapes
- null text fields
- invalid session row lengths

The new tests include links back to the corresponding `meganz/sdk` parser code used as the source of truth.

## Why

MEGA's real response shapes are more permissive than `mega-rs` previously assumed in these two endpoints. This change makes `mega-rs` accept valid MEGA output instead of failing on empty optional user-info attrs or positional session responses.
